### PR TITLE
fix: 修复 O2O SKU 预占聚合校验

### DIFF
--- a/backend/scripts/o2o-sku-selection-verify.ts
+++ b/backend/scripts/o2o-sku-selection-verify.ts
@@ -196,6 +196,20 @@ async function main() {
     pass('商城商品级价格跟随有库存的推荐 SKU')
 
     const clientAuth = await registerAndLoginClient(clientAuthService)
+    await assert.rejects(
+      () => o2oPreorderService.submit(clientAuth, {
+        items: [
+          { productId: product.id, qty: 3 },
+          { productId: product.id, skuId: otherSku.id, qty: 3 },
+        ],
+        remark: '规格别名超库存验证',
+        pickupContact: '规格验证提货人',
+        isSystemApplied: false,
+      }),
+      /库存不足/,
+    )
+    pass('下单前合并省略 SKU 与显式 SKU 后校验库存')
+
     const preorder = await o2oPreorderService.submit(clientAuth, {
       items: [{ productId: product.id, skuId: targetSku.id, qty: 2 }],
       remark: '规格 SKU 下单验证',
@@ -271,6 +285,20 @@ async function main() {
     assert.equal(defaultProductAfterUpdate.skus[0]?.discountRate, '8.0')
     assert.equal(defaultProductAfterUpdate.skus[0]?.availableStock, 6)
     pass('默认 SKU 商品主表单价格与库存同步到 SKU')
+
+    await assert.rejects(
+      () => o2oPreorderService.submit(clientAuth, {
+        items: [
+          { productId: defaultProduct.id, qty: 3 },
+          { productId: defaultProduct.id, skuId: defaultSkuId, qty: 3 },
+        ],
+        remark: '规格别名限购验证',
+        pickupContact: '规格验证提货人',
+        isSystemApplied: false,
+      }),
+      /超过限购数量/,
+    )
+    pass('下单前按商品聚合省略 SKU 与显式 SKU 后校验限购')
 
     const updatedPreorder = await o2oPreorderService.updateMyOrder(clientAuth, preorder.order.id, {
       items: [

--- a/backend/src/services/o2o-preorder.service.ts
+++ b/backend/src/services/o2o-preorder.service.ts
@@ -649,6 +649,30 @@ class O2oPreorderService {
     return fallbackSku
   }
 
+  /**
+   * 将可省略的 skuId 先解析为真实 SKU，再按 productId + 真实 skuId 合并。
+   * 这样可以避免“未传 skuId”和“显式传默认 skuId”指向同一规格时绕过库存或限购聚合校验。
+   */
+  private canonicalizePreorderItems(
+    normalizedItems: Array<{ productId: string; skuId: string | null; qty: number }>,
+    skuMap: Map<string, BaseProductSku>,
+    skuByProductMap: Map<string, BaseProductSku[]>,
+  ) {
+    const mergedQtyMap = new Map<string, { productId: string; skuId: string; qty: number }>()
+    normalizedItems.forEach((item) => {
+      const sku = this.getRequiredSku(skuMap, skuByProductMap, item.productId, item.skuId)
+      const skuId = String(sku.id)
+      const itemKey = this.buildOrderItemKey(item.productId, skuId)
+      const current = mergedQtyMap.get(itemKey)
+      mergedQtyMap.set(itemKey, {
+        productId: item.productId,
+        skuId,
+        qty: (current?.qty ?? 0) + item.qty,
+      })
+    })
+    return [...mergedQtyMap.values()]
+  }
+
   private groupSkusByProduct(skus: BaseProductSku[]) {
     const skuMap = new Map<string, BaseProductSku>()
     const skuByProductMap = new Map<string, BaseProductSku[]>()
@@ -1891,8 +1915,10 @@ class O2oPreorderService {
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },
       })
       const { skuMap, skuByProductMap } = this.groupSkusByProduct(skus)
+      const canonicalItems = this.canonicalizePreorderItems(normalizedItems, skuMap, skuByProductMap)
+      const productQtyMap = new Map<string, number>()
       let totalQty = 0
-      for (const row of normalizedItems) {
+      for (const row of canonicalItems) {
         const product = this.getRequiredProduct(productMap, row.productId)
         const sku = this.getRequiredSku(skuMap, skuByProductMap, row.productId, row.skuId)
         if (!product.isActive || product.o2oStatus !== 'listed') {
@@ -1907,8 +1933,10 @@ class O2oPreorderService {
         if (availableStock < row.qty) {
           throw new BizError(`规格「${sku.specText}」库存不足`, 409)
         }
+        const productQty = (productQtyMap.get(row.productId) ?? 0) + row.qty
+        productQtyMap.set(row.productId, productQty)
         const limitQty = this.resolveProductLimitQty(product, o2oRules)
-        if (o2oRules.limitEnabled && row.qty > limitQty) {
+        if (o2oRules.limitEnabled && productQty > limitQty) {
           throw new BizError(`商品「${product.productName}」超过限购数量`, 409)
         }
         totalQty += row.qty
@@ -1954,7 +1982,7 @@ class O2oPreorderService {
           timeoutAt,
         }),
       )
-      const itemEntities = normalizedItems.map((item) =>
+      const itemEntities = canonicalItems.map((item) =>
         (() => {
           const product = this.getRequiredProduct(productMap, item.productId)
           const sku = this.getRequiredSku(skuMap, skuByProductMap, item.productId, item.skuId)
@@ -1976,7 +2004,7 @@ class O2oPreorderService {
       )
       await manager.getRepository(O2oPreorderItem).save(itemEntities)
 
-      for (const row of normalizedItems) {
+      for (const row of canonicalItems) {
         const product = this.getRequiredProduct(productMap, row.productId)
         const sku = this.getRequiredSku(skuMap, skuByProductMap, row.productId, row.skuId)
         const beforeCurrentStock = Number(product.currentStock ?? 0)
@@ -2093,6 +2121,7 @@ class O2oPreorderService {
     o2oRules: Awaited<ReturnType<typeof systemConfigService.getO2oRuleConfigs>>,
   ) {
     let totalQty = 0
+    const productQtyMap = new Map<string, number>()
     normalizedItems.forEach((row) => {
       const product = productMap.get(row.productId)
       if (!product) {
@@ -2121,8 +2150,10 @@ class O2oPreorderService {
         throw new BizError(`规格「${sku.specText}」库存不足，当前最多可保留 ${effectiveAvailableStock} 件`, 409)
       }
 
+      const productQty = (productQtyMap.get(row.productId) ?? 0) + row.qty
+      productQtyMap.set(row.productId, productQty)
       const limitQty = this.resolveProductLimitQty(product, o2oRules)
-      if (o2oRules.limitEnabled && row.qty > limitQty) {
+      if (o2oRules.limitEnabled && productQty > limitQty) {
         throw new BizError(`商品「${product.productName}」超过限购数量`, 409)
       }
       totalQty += row.qty
@@ -2296,7 +2327,8 @@ class O2oPreorderService {
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },
       })
       const { skuMap, skuByProductMap } = this.groupSkusByProduct(skus)
-      const normalizedItemRefs = normalizedItems.map((item) => {
+      const canonicalItems = this.canonicalizePreorderItems(normalizedItems, skuMap, skuByProductMap)
+      const normalizedItemRefs = canonicalItems.map((item) => {
         const sku = this.getRequiredSku(skuMap, skuByProductMap, item.productId, item.skuId)
         return {
           productId: item.productId,
@@ -2311,7 +2343,7 @@ class O2oPreorderService {
         skuId: item.skuId ? String(item.skuId) : null,
       }))
       normalizedItemRefs.forEach((item) => itemKeyMap.set(item.itemKey, { productId: item.productId, skuId: item.skuId }))
-      const totalQty = this.validateUpdatedPreorderItems(normalizedItems, existingQtyMap, productMap, skuMap, skuByProductMap, o2oRules)
+      const totalQty = this.validateUpdatedPreorderItems(canonicalItems, existingQtyMap, productMap, skuMap, skuByProductMap, o2oRules)
 
       const nextQtyMap = new Map(normalizedItemRefs.map((item) => [item.itemKey, item.qty]))
       await this.applyPreorderItemStockDeltaInManager(
@@ -2329,7 +2361,7 @@ class O2oPreorderService {
         productMap,
         skuMap,
       )
-      await this.saveUpdatedPreorderItemsInManager(manager, order, existingItems, normalizedItems, nextQtyMap, productMap, skuMap, skuByProductMap)
+      await this.saveUpdatedPreorderItemsInManager(manager, order, existingItems, canonicalItems, nextQtyMap, productMap, skuMap, skuByProductMap)
 
       order.totalQty = totalQty
       order.remark = normalizedRemark
@@ -2372,7 +2404,8 @@ class O2oPreorderService {
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },
       })
       const { skuMap, skuByProductMap } = this.groupSkusByProduct(skus)
-      const normalizedItemRefs = normalizedItems.map((item) => {
+      const canonicalItems = this.canonicalizePreorderItems(normalizedItems, skuMap, skuByProductMap)
+      const normalizedItemRefs = canonicalItems.map((item) => {
         const sku = this.getRequiredSku(skuMap, skuByProductMap, item.productId, item.skuId)
         return {
           productId: item.productId,
@@ -2387,7 +2420,7 @@ class O2oPreorderService {
         skuId: item.skuId ? String(item.skuId) : null,
       }))
       normalizedItemRefs.forEach((item) => itemKeyMap.set(item.itemKey, { productId: item.productId, skuId: item.skuId }))
-      const totalQty = this.validateUpdatedPreorderItems(normalizedItems, existingQtyMap, productMap, skuMap, skuByProductMap, o2oRules)
+      const totalQty = this.validateUpdatedPreorderItems(canonicalItems, existingQtyMap, productMap, skuMap, skuByProductMap, o2oRules)
       const nextQtyMap = new Map(normalizedItemRefs.map((item) => [item.itemKey, item.qty]))
 
       await this.applyPreorderItemStockDeltaInManager(
@@ -2405,7 +2438,7 @@ class O2oPreorderService {
         productMap,
         skuMap,
       )
-      await this.saveUpdatedPreorderItemsInManager(manager, order, existingItems, normalizedItems, nextQtyMap, productMap, skuMap, skuByProductMap)
+      await this.saveUpdatedPreorderItemsInManager(manager, order, existingItems, canonicalItems, nextQtyMap, productMap, skuMap, skuByProductMap)
 
       order.totalQty = totalQty
       order.remark = normalizedRemark


### PR DESCRIPTION
### Motivation
- 修复当客户端在同一商品同时提交“省略 skuId 的行”与“显式 skuId 的行”时因为在解析默认 SKU 之前就按原始 key 合并而导致的库存预占/限购绕过漏洞。 
- 该问题会导致同一真实 SKU 被重复校验并重复写入 `preOrderedStock`，从而可能使某个 SKU 超额预占库存或绕过商品层限购。

### Description
- 新增 `canonicalizePreorderItems` 方法，会先把可省略的 `skuId` 解析为真实 SKU，然后按 `productId+真实 skuId` 合并请求行；修改点在 `backend/src/services/o2o-preorder.service.ts`。 
- 将下单流程、客户端改单与门店现场改单统一改为基于 canonical 明细执行库存校验、限购聚合校验、订单明细保存与 SKU 预占写入，相关改动集中在 `submit`、`updateMyOrder`、`updateOrderOnsite` 与 `validateUpdatedPreorderItems`。 
- 把按行限购校验改为按商品聚合后的数量判断，避免通过拆分别名行绕过限购。 
- 补充并调整了验证脚本 `backend/scripts/o2o-sku-selection-verify.ts`，新增用例覆盖“省略 SKU + 显式 SKU 混合提交会被拒绝（库存/限购）”场景。

### Testing
- 在后端运行专项验证脚本 `npm --prefix backend run o2o:sku-selection:verify`，脚本通过并输出所有断言均为 OK。 
- 进行后端构建 `npm --prefix backend run build`，TypeScript 编译通过且无错误。 
- 运行文本编码检查 `npm run verify:text-encoding`，检查通过且未发现乱码特征词。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a419e2168e08320b844a2d5aabcd596)