### PR TITLE
fix(ci): 加固 ACR 发布变量校验

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,10 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
+      HAS_DOCKERHUB_CREDS: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+      HAS_ACR_CREDS: ${{ secrets.ACR_USERNAME != '' && secrets.ACR_PASSWORD != '' }}
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -33,35 +31,79 @@ jobs:
       - name: 计算镜像仓库与推送规则
         id: prepare
         shell: bash
+        env:
+          DOCKERHUB_NAMESPACE_VAR: ${{ vars.DOCKERHUB_NAMESPACE }}
+          ACR_REGISTRY_VAR: ${{ vars.ACR_REGISTRY }}
+          ACR_NAMESPACE_VAR: ${{ vars.ACR_NAMESPACE }}
+          ACR_PUSH_MODE_VAR: ${{ vars.ACR_PUSH_MODE }}
+          DEFAULT_ACR_REGISTRY: crpi-9gmsq2s17re73ia9.cn-qingdao.personal.cr.aliyuncs.com
+          DEFAULT_ACR_NAMESPACE: yyh163
         run: |
-          namespace="${{ vars.DOCKERHUB_NAMESPACE }}"
+          set -euo pipefail
+
+          write_output() {
+            local key="$1"
+            local value="$2"
+            if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+              echo "Invalid output key: $key" >&2
+              exit 1
+            fi
+            if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+              echo "Invalid multiline value for output: $key" >&2
+              exit 1
+            fi
+            printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+          }
+
+          namespace="${DOCKERHUB_NAMESPACE_VAR:-}"
           if [ -z "$namespace" ]; then
-            namespace="${{ github.repository_owner }}"
+            namespace="${GITHUB_REPOSITORY_OWNER}"
           fi
-          namespace="$(echo "$namespace" | tr '[:upper:]' '[:lower:]')"
-          echo "namespace=$namespace" >> "$GITHUB_OUTPUT"
+          namespace="$(printf '%s' "$namespace" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$namespace" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+            echo "Invalid DOCKERHUB_NAMESPACE; only Docker namespace characters are allowed." >&2
+            exit 1
+          fi
+          write_output "namespace" "$namespace"
 
-          gh_owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
-          echo "gh_owner=$gh_owner" >> "$GITHUB_OUTPUT"
+          gh_owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          write_output "gh_owner" "$gh_owner"
 
-          acr_registry="${{ vars.ACR_REGISTRY }}"
+          acr_registry="${ACR_REGISTRY_VAR:-}"
           if [ -z "$acr_registry" ]; then
-            acr_registry="crpi-9gmsq2s17re73ia9.cn-qingdao.personal.cr.aliyuncs.com"
+            acr_registry="$DEFAULT_ACR_REGISTRY"
           fi
-          acr_namespace="${{ vars.ACR_NAMESPACE }}"
+          acr_namespace="${ACR_NAMESPACE_VAR:-}"
           if [ -z "$acr_namespace" ]; then
-            acr_namespace="yyh163"
+            acr_namespace="$DEFAULT_ACR_NAMESPACE"
           fi
-          acr_push_mode="${{ vars.ACR_PUSH_MODE }}"
+          acr_push_mode="${ACR_PUSH_MODE_VAR:-}"
           if [ -z "$acr_push_mode" ]; then
             acr_push_mode="release_tag_only"
           fi
-          echo "acr_registry=$acr_registry" >> "$GITHUB_OUTPUT"
-          echo "acr_namespace=$acr_namespace" >> "$GITHUB_OUTPUT"
-          echo "acr_push_mode=$acr_push_mode" >> "$GITHUB_OUTPUT"
+
+          if [[ ! "$acr_registry" =~ ^[a-z0-9][a-z0-9.-]*\.aliyuncs\.com$ ]]; then
+            echo "Invalid ACR_REGISTRY; only Aliyun ACR registry hosts are allowed." >&2
+            exit 1
+          fi
+          if [[ ! "$acr_namespace" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+            echo "Invalid ACR_NAMESPACE; only registry namespace characters are allowed." >&2
+            exit 1
+          fi
+          case "$acr_push_mode" in
+            all|release_tag_only)
+              ;;
+            *)
+              echo "Unsupported ACR_PUSH_MODE=$acr_push_mode, fallback to release_tag_only"
+              acr_push_mode="release_tag_only"
+              ;;
+          esac
+          write_output "acr_registry" "$acr_registry"
+          write_output "acr_namespace" "$acr_namespace"
+          write_output "acr_push_mode" "$acr_push_mode"
 
           acr_enabled="false"
-          if [ -n "${ACR_USERNAME}" ] && [ -n "${ACR_PASSWORD}" ]; then
+          if [ "${HAS_ACR_CREDS}" = "true" ]; then
             case "$acr_push_mode" in
               all)
                 acr_enabled="true"
@@ -71,22 +113,16 @@ jobs:
                   acr_enabled="true"
                 fi
                 ;;
-              *)
-                echo "Unsupported ACR_PUSH_MODE=$acr_push_mode, fallback to release_tag_only"
-                if [[ "${GITHUB_REF}" == refs/tags/release-v* ]]; then
-                  acr_enabled="true"
-                fi
-                ;;
             esac
           fi
-          echo "acr_enabled=$acr_enabled" >> "$GITHUB_OUTPUT"
+          write_output "acr_enabled" "$acr_enabled"
 
           frontend_images="ghcr.io/${gh_owner}/y-link-frontend"
           backend_images="ghcr.io/${gh_owner}/y-link-backend"
           onebox_images="ghcr.io/${gh_owner}/y-link-onebox"
 
           # Docker Hub 可选推送
-          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+          if [ "${HAS_DOCKERHUB_CREDS}" = "true" ]; then
             frontend_images="docker.io/${namespace}/y-link-frontend"$'\n'"${frontend_images}"
             backend_images="docker.io/${namespace}/y-link-backend"$'\n'"${backend_images}"
             onebox_images="docker.io/${namespace}/y-link-onebox"$'\n'"${onebox_images}"
@@ -119,11 +155,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: 登录 Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ env.HAS_DOCKERHUB_CREDS == 'true' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 登录 GitHub Container Registry
         uses: docker/login-action@v4
@@ -137,8 +173,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ steps.prepare.outputs.acr_registry }}
-          username: ${{ env.ACR_USERNAME }}
-          password: ${{ env.ACR_PASSWORD }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
 
       - name: 生成前端镜像元数据
         id: frontend_meta


### PR DESCRIPTION
### Motivation
- 修复 GitHub Actions 流水线中通过 `vars` 直接插入到 bash 脚本并写入 `GITHUB_OUTPUT` 导致的命令/输出注入与凭据外泄风险（ACR/DockerHub 凭据可能被发送到非预期 registry）。

### Description
- 将作业级 `env` 中对真实凭据的暴露移除，只保留凭据存在性的布尔变量 `HAS_DOCKERHUB_CREDS` 和 `HAS_ACR_CREDS`，并将 `vars` 值通过 step `env` 安全传入 `prepare` 步骤；修改文件：`.github/workflows/docker-publish.yml`。 
- 在 `prepare` step 中启用 `set -euo pipefail` 并新增 `write_output` 函数以校验输出 key 格式与拒绝包含换行/回车的输出值，从而阻断多行输出注入写入 `GITHUB_OUTPUT`。 
- 为 Docker Hub namespace、ACR registry、ACR namespace 和 ACR push mode 增加严格正则校验，并将 ACR registry 限定为 Aliyun ACR 域名格式，防止将凭据发送到攻击者控制的 registry。 
- 登录步骤改为在真正执行 `docker/login-action` 时才引用 `secrets`，并用布尔条件判断是否登录，避免在脚本中接触敏感值。 

### Testing
- 运行 `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-publish.yml"); puts "yaml ok"'` 验证 YAML 语法，结果成功。 
- 抽取并以默认变量运行 `prepare` 脚本（模拟正常场景），验证输出包含预期的 `frontend_images`/`backend_images`/`onebox_images`，结果成功。 
- 使用带命令替换与换行的恶意 `ACR_REGISTRY`/`ACR_NAMESPACE` 变量运行 `prepare` 脚本，验证恶意 payload 被拒绝且未执行（未产生外部文件），结果被拒绝且未执行。 
- 运行 `npm run verify:text-encoding` 验证文本编码，结果成功；运行 `git diff --check` 无残留格式错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41aca410fc8320a4deb564b1cd9479)