### PR TITLE
fix(auth): 不信任客户端风控头作为频控主键

### DIFF
--- a/backend/src/services/auth-security.service.ts
+++ b/backend/src/services/auth-security.service.ts
@@ -201,13 +201,11 @@ const requestWindowStore = new Map<string, number[]>()
 /**
  * 登录失败态：
  * - 管理端继续按“来源 IP”和“账号/手机号”记录；
- * - 客户端优先按“浏览器会话/浏览器实例”和“账号/手机号”记录，降低共享公网 IP 的误伤。
+ * - 客户端公共认证接口按“来源 IP”和“账号/手机号”记录，避免信任未认证请求可随意伪造的浏览器风险请求头。
  */
 const failureStateStore = new Map<string, FailureState>()
 
 const normalizeRiskSource = (meta?: RequestMeta) => meta?.ipAddress?.trim() || 'unknown-ip'
-const normalizeClientRiskBrowserId = (meta?: RequestMeta) => meta?.clientRiskBrowserId?.trim() || ''
-const normalizeClientRiskSessionId = (meta?: RequestMeta) => meta?.clientRiskSessionId?.trim() || ''
 
 export class AuthSecurityService {
   private trimRateLimitWindow(timestamps: number[], windowMs: number, nowMs: number) {
@@ -373,24 +371,11 @@ export class AuthSecurityService {
   }
 
   private resolveClientRiskActor(requestMeta?: RequestMeta): ClientRiskActor {
-    const sessionRiskId = normalizeClientRiskSessionId(requestMeta)
-    if (sessionRiskId) {
-      return {
-        source: sessionRiskId,
-        sourceType: 'session',
-        bucketSegment: `session:${sessionRiskId}`,
-      }
-    }
-
-    const browserRiskId = normalizeClientRiskBrowserId(requestMeta)
-    if (browserRiskId) {
-      return {
-        source: browserRiskId,
-        sourceType: 'browser',
-        bucketSegment: `browser:${browserRiskId}`,
-      }
-    }
-
+    /**
+     * 客户端风控请求头来自未认证客户端，不能作为频控桶或登录失败锁定的主键。
+     * 这里保留 RequestMeta 中的浏览器/会话标识供审计排查使用，但认证防护主链路只按服务端解析出的 IP 聚合，
+     * 避免攻击者轮换 `x-client-risk-session-id` / `x-client-risk-browser-id` 绕过失败态或制造无界内存键。
+     */
     const ipAddress = normalizeRiskSource(requestMeta)
     return {
       source: ipAddress,


### PR DESCRIPTION
### Motivation
- 修复因后端将未认证的 `x-client-risk-session-id` / `x-client-risk-browser-id` 直接作为频控与失败态主键导致的可利用性与绕过风险。\n- 攻击者可通过轮换这些头制造大量唯一键耗尽进程内存或规避每源失败锁定，需收敛可信聚合维度以保障可用性。\n
### Description
- 将客户端公共认证防护的风险聚合主键改为服务端解析出的来源 IP，避免信任未认证请求可伪造的风险头。\n- 在 `backend/src/services/auth-security.service.ts` 中移除对客户端风险头作为频控桶/失败锁定主链路的使用，`resolveClientRiskActor` 现在仅返回 IP 聚合桶。\n- 保留 `RequestMeta` 中风险头用于审计排查，但不参与频控或登录失败计数，以防止轮换头引发无界内存键。\n- 更新了相关注释以反映新的信任边界（仅修改 `backend/src/services/auth-security.service.ts`）。\n
### Testing
- 运行 `npm --prefix backend run build` 成功，TypeScript 编译通过。\n- 用本地 `tsx` 执行回归脚本 `./backend/node_modules/.bin/tsx --tsconfig backend/tsconfig.json /tmp/client-risk-regression.ts`，脚本断言通过并输出 `风险头轮换已按同一 IP 聚合：allowed=18, blocked=7, firstBlockedAt=19`，验证轮换风险头不再创建独立频控桶。\n- 运行 `npm --prefix backend run security:hardening:verify` 执行安全检测脚本，全部项通过（输出含多项 OK）。\n

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41b4abca5083208119aa2a6caa22b1)