### PR TITLE
fix(反馈附件): 加固上传迁移路径校验

### DIFF
--- a/backend/src/services/client-feedback.service.ts
+++ b/backend/src/services/client-feedback.service.ts
@@ -38,6 +38,7 @@ import type { AuthUserContext } from '../types/auth.js'
 import type { ClientAuthContext } from '../types/client-auth.js'
 import { isUniqueConstraintError } from '../utils/database-errors.js'
 import { BizError } from '../utils/errors.js'
+import { isUploadPublicUrlForCategory } from '../utils/upload-storage.js'
 import type { RequestMeta } from '../utils/request-meta.js'
 import { auditService } from './audit.service.js'
 import {
@@ -372,6 +373,9 @@ class ClientFeedbackService {
       }
       if (url.length > CLIENT_FEEDBACK_ATTACHMENT_URL_MAX_LENGTH) {
         throw new BizError(`附件地址长度不能超过 ${CLIENT_FEEDBACK_ATTACHMENT_URL_MAX_LENGTH} 个字符`, 400)
+      }
+      if (!isUploadPublicUrlForCategory('client-feedback', url)) {
+        throw new BizError(`第 ${index + 1} 个附件地址必须来自反馈附件上传接口`, 400)
       }
       if (mimeType && mimeType.length > CLIENT_FEEDBACK_ATTACHMENT_MIME_TYPE_MAX_LENGTH) {
         throw new BizError(`附件类型长度不能超过 ${CLIENT_FEEDBACK_ATTACHMENT_MIME_TYPE_MAX_LENGTH} 个字符`, 400)

--- a/backend/src/utils/upload-migration.ts
+++ b/backend/src/utils/upload-migration.ts
@@ -9,9 +9,15 @@ import path from 'node:path'
 import type { DataSource } from 'typeorm'
 import { BaseProduct } from '../entities/base-product.entity.js'
 import { ClientFeedbackMessage, type ClientFeedbackMessageAttachment } from '../entities/client-feedback-message.entity.js'
-import { buildUploadPublicUrl, ensureUploadCategoryDir, type UploadCategory } from './upload-storage.js'
+import {
+  buildUploadPublicUrl,
+  ensureUploadCategoryDir,
+  UPLOAD_PUBLIC_FILE_NAME_MATCHER,
+  type UploadCategory,
+} from './upload-storage.js'
 
 const LEGACY_UPLOAD_URL_MATCHER = /^\/uploads\/([^/]+)$/
+const RESERVED_UPLOAD_ROOT_NAMES = new Set<UploadCategory>(['products', 'client-feedback'])
 
 export interface UploadMigrationResult {
   productThumbnailUpdatedCount: number
@@ -25,7 +31,14 @@ const resolveLegacyUploadFileName = (url?: string | null) => {
     return null
   }
   const match = LEGACY_UPLOAD_URL_MATCHER.exec(normalizedUrl)
-  return match?.[1] ?? null
+  const fileName = match?.[1]?.trim()
+  if (!fileName || RESERVED_UPLOAD_ROOT_NAMES.has(fileName as UploadCategory)) {
+    return null
+  }
+  if (!UPLOAD_PUBLIC_FILE_NAME_MATCHER.test(fileName)) {
+    return null
+  }
+  return fileName
 }
 
 const moveLegacyUploadFileIfNeeded = (
@@ -37,10 +50,18 @@ const moveLegacyUploadFileIfNeeded = (
   const targetDir = ensureUploadCategoryDir(category)
   const targetFilePath = path.resolve(targetDir, fileName)
 
+  if (path.dirname(legacyFilePath) !== uploadsRootDir || path.dirname(targetFilePath) !== targetDir) {
+    return false
+  }
   if (fs.existsSync(targetFilePath)) {
     return false
   }
   if (!fs.existsSync(legacyFilePath)) {
+    return false
+  }
+
+  const legacyFileStat = fs.lstatSync(legacyFilePath)
+  if (!legacyFileStat.isFile()) {
     return false
   }
 

--- a/backend/src/utils/upload-storage.ts
+++ b/backend/src/utils/upload-storage.ts
@@ -78,6 +78,16 @@ export const buildUploadPublicUrl = (category: UploadCategory, fileName: string)
   return `/uploads/${category}/${fileName}`
 }
 
+export const UPLOAD_PUBLIC_FILE_NAME_MATCHER =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(?:jpg|jpeg|png|webp|gif)$/i
+
+export const isUploadPublicUrlForCategory = (category: UploadCategory, value: string) => {
+  const normalizedValue = value.trim()
+  const escapedCategory = category.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = new RegExp(`^/uploads/${escapedCategory}/([^/]+)$`).exec(normalizedValue)
+  return Boolean(match?.[1] && UPLOAD_PUBLIC_FILE_NAME_MATCHER.test(match[1]))
+}
+
 /**
  * 根据图片文件头识别真实内容类型：
  * - JPEG 识别 `FF D8 FF`；


### PR DESCRIPTION
### Motivation

- 修复启动迁移对客户端可控 `attachment.url` 的信任导致的持久化 DoS/目录污染风险；迁移不可再盲目对 `/uploads/<name>` 单段路径做 `fs.renameSync`。  

### Description

- 在 `backend/src/utils/upload-storage.ts` 新增 `UPLOAD_PUBLIC_FILE_NAME_MATCHER` 与 `isUploadPublicUrlForCategory()`，只认可 `/uploads/<category>/<uuid>.<ext>` 格式的受控上传文件名。  
- 在 `backend/src/services/client-feedback.service.ts` 的附件归一化校验中加入分类 URL 校验，拒绝非上传接口生成的路径从而阻断目录型载荷入库。  
- 在 `backend/src/utils/upload-migration.ts` 中对旧单层路径解析与搬运做收缩：排除保留目录名、仅处理符合白名单的 UUID 文件名、增加目录边界校验并用 `lstat` 确认为常规文件后才 `rename`，避免目录、符号链接或异常路径触发启动期异常或目录移动。  
- 仅修改三处文件，变更点较小，保持现有上传/转正逻辑与静态 URL 生成不变。  

### Testing

- 运行 `npm --prefix backend run build` 成功构建，类型检查通过。  
- 运行上传安全回归脚本 `npm --prefix backend run task4:upload-security:verify`，验证图片内容识别、重编码、旧路径兼容与静态头策略，全部通过。  
- 运行自建迁移检查脚本（`/tmp/ylink-upload-migration-check.ts`）通过，验证：恶意目录型载荷被忽略且合法 legacy 文件能被迁移。  
- 运行小脚本验证 `isUploadPublicUrlForCategory` 白名单行为（通过 `npm exec -- tsx -e ...`）和 `git diff --check`，均通过且无回归。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41b77a52e08320bbbd7213945d5c65)