### PR TITLE
ci(docker): 收窄镜像发布凭据作用域

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,10 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -33,6 +29,11 @@ jobs:
       - name: 计算镜像仓库与推送规则
         id: prepare
         shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+          ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
         run: |
           namespace="${{ vars.DOCKERHUB_NAMESPACE }}"
           if [ -z "$namespace" ]; then
@@ -86,11 +87,14 @@ jobs:
           onebox_images="ghcr.io/${gh_owner}/y-link-onebox"
 
           # Docker Hub 可选推送
+          dockerhub_enabled="false"
           if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            dockerhub_enabled="true"
             frontend_images="docker.io/${namespace}/y-link-frontend"$'\n'"${frontend_images}"
             backend_images="docker.io/${namespace}/y-link-backend"$'\n'"${backend_images}"
             onebox_images="docker.io/${namespace}/y-link-onebox"$'\n'"${onebox_images}"
           fi
+          echo "dockerhub_enabled=$dockerhub_enabled" >> "$GITHUB_OUTPUT"
 
           # 阿里云 ACR 可选推送
           # onebox 默认推到 y-link，方便直接用于部署
@@ -119,11 +123,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: 登录 Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ steps.prepare.outputs.dockerhub_enabled == 'true' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 登录 GitHub Container Registry
         uses: docker/login-action@v4
@@ -137,8 +141,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ steps.prepare.outputs.acr_registry }}
-          username: ${{ env.ACR_USERNAME }}
-          password: ${{ env.ACR_PASSWORD }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
 
       - name: 生成前端镜像元数据
         id: frontend_meta


### PR DESCRIPTION
### Motivation
- 修复 GitHub Actions 工作流中将 Docker Hub / ACR 凭据放在 job 级 `env` 导致所有 steps 和第三方 actions 继承敏感凭据的供应链暴露问题。

### Description
- 从 `publish` job 的顶层 `env` 中移除 `DOCKERHUB_USERNAME`、`DOCKERHUB_TOKEN`、`ACR_USERNAME` 与 `ACR_PASSWORD`，只保留非敏感环境变量 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`。
- 将凭据限定到计算推送规则的 shell 步骤（`prepare`），通过该步骤的局部 `env` 读取 secrets 并导出 `dockerhub_enabled` / `acr_enabled` 输出以控制后续登录步骤的执行逻辑。
- 将 Docker Hub 与 ACR 的登录步骤改为在 `with` 中直接引用对应的 `secrets`，并用 `steps.prepare.outputs.dockerhub_enabled == 'true'` / `steps.prepare.outputs.acr_enabled == 'true'` 作为登录条件，从而避免将原始 token 暴露给同一 job 中的其他 actions。
- 仅调整工作流范围和条件判断，不改变原有的可选推送行为或镜像标签/构建逻辑，保持对 Docker Hub、GHCR 和 ACR 的多目标推送能力。

### Testing
- 运行用于校验的 Python 断言脚本（等价于仓内脚本片段），验证 job 级 `env` 不再包含 `DOCKERHUB_USERNAME`、`DOCKERHUB_TOKEN`、`ACR_USERNAME`、`ACR_PASSWORD`，且登录条件切换为 `steps.prepare.outputs.dockerhub_enabled == 'true'`，结果：通过。
- 运行 `npm run verify:text-encoding` 检查文本编码与中文内容，结果：未发现乱码特征词（通过）。
- 运行 `git diff --check` 检查工作树差异问题，结果：未发现问题（通过）。

已修改文件：`.github/workflows/docker-publish.yml`。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41c9666c94832094fd31e0e47f2476)