### PR TITLE
fix(auth): 限制认证风控内存桶增长

### DIFF
--- a/backend/src/services/auth-security.service.ts
+++ b/backend/src/services/auth-security.service.ts
@@ -190,6 +190,12 @@ const FAILURE_RESET_WINDOW_MS = {
 
 const LOGIN_REMAINING_WARNING_RATIO = 0.2
 const REGISTER_REMAINING_WARNING_THRESHOLD = 3
+const MAX_RATE_LIMIT_BUCKETS = 10000
+const MAX_FAILURE_STATE_BUCKETS = 5000
+const STORE_CLEANUP_INTERVAL_MS = 60 * 1000
+const MAX_RATE_LIMIT_WINDOW_MS = Math.max(...Object.values(RATE_LIMIT_RULES).map((rule) => rule.windowMs))
+
+let lastStoreCleanupAt = 0
 
 /**
  * 内存态时间窗口记录：
@@ -212,6 +218,44 @@ const normalizeClientRiskSessionId = (meta?: RequestMeta) => meta?.clientRiskSes
 export class AuthSecurityService {
   private trimRateLimitWindow(timestamps: number[], windowMs: number, nowMs: number) {
     return timestamps.filter((timestamp) => nowMs - timestamp < windowMs)
+  }
+
+  private cleanupStores(nowMs: number) {
+    if (nowMs - lastStoreCleanupAt < STORE_CLEANUP_INTERVAL_MS) {
+      return
+    }
+    lastStoreCleanupAt = nowMs
+
+    for (const [key, timestamps] of requestWindowStore) {
+      const activeWindow = this.trimRateLimitWindow(timestamps, MAX_RATE_LIMIT_WINDOW_MS, nowMs)
+      if (activeWindow.length) {
+        requestWindowStore.set(key, activeWindow)
+      } else {
+        requestWindowStore.delete(key)
+      }
+    }
+
+    for (const [key, state] of failureStateStore) {
+      const isExpired =
+        state.lockedUntil <= nowMs &&
+        nowMs - state.lastFailedAt >= Math.max(...Object.values(FAILURE_RESET_WINDOW_MS))
+      if (isExpired) {
+        failureStateStore.delete(key)
+      }
+    }
+
+    this.evictOldestEntries(requestWindowStore, MAX_RATE_LIMIT_BUCKETS)
+    this.evictOldestEntries(failureStateStore, MAX_FAILURE_STATE_BUCKETS)
+  }
+
+  private evictOldestEntries(store: Map<string, unknown>, maxSize: number) {
+    while (store.size > maxSize) {
+      const oldestKey = store.keys().next().value
+      if (oldestKey === undefined) {
+        return
+      }
+      store.delete(oldestKey)
+    }
   }
 
   private async recordRiskEvent(input: {
@@ -244,6 +288,7 @@ export class AuthSecurityService {
     },
   ): Promise<RateLimitConsumeResult> {
     const nowMs = Date.now()
+    this.cleanupStores(nowMs)
     const existing = requestWindowStore.get(bucketKey) ?? []
     const activeWindow = this.trimRateLimitWindow(existing, rule.windowMs, nowMs)
     if (activeWindow.length >= rule.maxRequests) {
@@ -263,6 +308,7 @@ export class AuthSecurityService {
     }
     activeWindow.push(nowMs)
     requestWindowStore.set(bucketKey, activeWindow)
+    this.evictOldestEntries(requestWindowStore, MAX_RATE_LIMIT_BUCKETS)
     return {
       remainingRequests: Math.max(0, rule.maxRequests - activeWindow.length),
       maxRequests: rule.maxRequests,
@@ -314,6 +360,7 @@ export class AuthSecurityService {
     subjectKey: string,
   ): Promise<LoginFailureRecordResult> {
     const nowMs = Date.now()
+    this.cleanupStores(nowMs)
     for (const storeKey of [sourceKey, subjectKey]) {
       const current = this.getFailureState(storeKey, scope, nowMs)
       const next: FailureState = current
@@ -333,6 +380,7 @@ export class AuthSecurityService {
       }
       failureStateStore.set(storeKey, next)
     }
+    this.evictOldestEntries(failureStateStore, MAX_FAILURE_STATE_BUCKETS)
 
     const currentSubjectState = failureStateStore.get(subjectKey)
     const remainingAttempts = Math.max(0, FAILURE_LOCK_THRESHOLD[scope] - (currentSubjectState?.count ?? 0))

--- a/backend/src/utils/request-meta.ts
+++ b/backend/src/utils/request-meta.ts
@@ -3,7 +3,7 @@
  * 文件职责：从 Express 请求对象中提取审计与风控所需的来源信息，统一输出 IP、UA 与客户端风险标识。
  * 实现逻辑：
  * 1. 先对风险标识请求头做裁剪与白名单校验，拦截非法格式值进入后续链路；
- * 2. 仅在应用显式启用可信代理时才信任 `x-forwarded-for`，避免伪造来源 IP；
+ * 2. 来源 IP 统一使用 Express 基于 trust proxy 计算后的 req.ip，不直接解析可伪造的 x-forwarded-for；
  * 3. 最终返回审计服务可直接复用的请求元信息对象，减少各模块自行解析请求头。
  */
 
@@ -36,33 +36,13 @@ const normalizeRiskHeader = (headerValue: unknown) => {
 
 /**
  * 提取请求侧元信息：
- * - 默认不信任 x-forwarded-for，防止客户端伪造来源 IP；
- * - 仅在应用显式启用可信代理（trust proxy）时，才读取 x-forwarded-for 首个 IP；
- * - 否则回退使用 Express 提供的 req.ip，保障审计链路安全一致。
+ * - 不直接读取 x-forwarded-for 首个值，防止客户端预置伪造 IP 后被风控信任；
+ * - 来源 IP 统一交给 Express 的 trust proxy 规则计算，未配置可信代理时 req.ip 会回退到直连地址；
+ * - 保障审计与频控使用同一套不可由匿名请求任意指定的来源口径。
  */
 export function extractRequestMeta(req: Request): RequestMeta {
-  // Express 默认 trust proxy=false；只有显式配置可信代理后才允许信任代理头。
-  const trustProxySetting = req.app.get('trust proxy')
-  const isTrustedProxyEnabled =
-    trustProxySetting !== false &&
-    trustProxySetting !== undefined &&
-    trustProxySetting !== null &&
-    trustProxySetting !== 0 &&
-    trustProxySetting !== '0' &&
-    trustProxySetting !== ''
-
-  let forwardedIp: string | undefined
-  if (isTrustedProxyEnabled) {
-    const forwardedFor = req.headers['x-forwarded-for']
-    if (typeof forwardedFor === 'string') {
-      forwardedIp = forwardedFor.split(',')[0]?.trim()
-    } else if (Array.isArray(forwardedFor)) {
-      forwardedIp = forwardedFor[0]?.split(',')[0]?.trim()
-    }
-  }
-
   return {
-    ipAddress: forwardedIp || req.ip || null,
+    ipAddress: req.ip || null,
     userAgent: typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : null,
     clientRiskBrowserId: normalizeRiskHeader(req.headers['x-client-risk-browser-id']),
     clientRiskSessionId: normalizeRiskHeader(req.headers['x-client-risk-session-id']),


### PR DESCRIPTION
### Motivation
- 修复后端认证风控使用模块级内存 Map 保存频控/失败状态导致匿名请求可通过伪造来源（X-Forwarded-For）持续创建唯一桶，最终引发 Node.js 堆内存耗尽的可用性风险。

### Description
- 为风控内存存储增加阈值与回收策略：新增 `MAX_RATE_LIMIT_BUCKETS = 10000`、`MAX_FAILURE_STATE_BUCKETS = 5000` 和定期清理间隔 `STORE_CLEANUP_INTERVAL_MS = 60 * 1000`，并实现 `cleanupStores` 与 `evictOldestEntries` 以修剪窗口、删除过期失败态并按最旧条目淘汰超额桶；变更位于 `backend/src/services/auth-security.service.ts`。 
- 在频控消耗和记录失败时调用清理/淘汰逻辑：在 `consumeRateLimit` 与 `recordLoginFailure` 调用 `cleanupStores` 并在写入后执行桶数量限制检查，防止单次写入导致无限增长；相关改动在 `backend/src/services/auth-security.service.ts`。 
- 不再直接信任并解析 `X-Forwarded-For` 首个值作为风控 IP 来源，而是统一使用 Express 由 `trust proxy` 规则计算后的 `req.ip` 作为 `ipAddress`，以避免匿名请求伪造来源绕过 IP 限频，改动位于 `backend/src/utils/request-meta.ts`（同时更新了注释说明）。 
- 受影响文件：`backend/src/services/auth-security.service.ts`、`backend/src/utils/request-meta.ts`。 

### Testing
- 运行 `npm --prefix backend run build`：构建通过（成功）。
- 运行 `npm --prefix backend run security:hardening:verify`：安全校验脚本通过（成功）。
- 运行 `npm run verify:text-encoding`：文本编码检查通过（成功）。
- 运行 `npm --prefix backend run task2:route-contract:verify`：验证失败，错误为若干报表路由在全局鉴权后未声明权限点（`GET /api/reports/inventory` 等），该失败与本次内存桶与来源信任修复无关。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41d3cf7bec83209221ea81e200c2ee)