### PR TITLE
fix(dashboard): 转义 ECharts 饼图 tooltip 标签以修复存储型 XSS

### DIFF
--- a/src/views/dashboard/components/DashboardPieSection.vue
+++ b/src/views/dashboard/components/DashboardPieSection.vue
@@ -87,6 +87,15 @@ const formatSliceValue = (value: NumericLike, valueType: PieValueType): string =
   return `¥${formatAmount(value)}`
 }
 
+const escapeTooltipHtml = (value: unknown): string => {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 const resolvePieLegendColor = (index: number): string => {
   return piePalette[index % piePalette.length]
 }
@@ -118,7 +127,7 @@ const buildPieOption = (slices: DashboardPieSlice[], valueType: PieValueType): E
         const rawValue = normalizedParams.value
         const normalizedValue = typeof rawValue === 'number' || typeof rawValue === 'string' ? rawValue : 0
         return [
-          `<div style="font-weight:600;margin-bottom:4px;">${normalizedParams.name}</div>`,
+          `<div style="font-weight:600;margin-bottom:4px;">${escapeTooltipHtml(normalizedParams.name)}</div>`,
           `<div>占比：${percent}%</div>`,
           `<div>${valueType === 'count' ? '单数' : '金额'}：${formatSliceValue(normalizedValue, valueType)}</div>`,
         ].join('')


### PR DESCRIPTION
### Motivation
- 修复仪表盘饼图在 ECharts HTML tooltip 中直接插入业务标签（商品名/客户部门名）导致的存储型 XSS 风险。 
- 漏洞来源为 tooltip `formatter` 返回 HTML 字符串并未对 `params.name` 做转义，从而允许含有 `onerror` 等载荷的标签被渲染执行。 
- 本次变更使用 `ylink-admin-business-workbench` 工作流定位并修改管理端工作台相关组件，因为问题影响仪表盘展示链路。 

### Description
- 在 `src/views/dashboard/components/DashboardPieSection.vue` 中新增 `escapeTooltipHtml` 辅助函数用于对 `& < > " '` 做 HTML 实体转义，以阻断 HTML 注入。 
- 在 ECharts tooltip 的 `formatter` 中将原本直接插入的 `normalizedParams.name` 替换为 `escapeTooltipHtml(normalizedParams.name)`，保持 tooltip 布局与数值显示逻辑不变。 
- 仅修改前端展示层以消除 DOM XSS 风险，不改动后端数据源、接口或业务聚合逻辑。 

### Testing
- 已执行 `npm run build`（前端构建），构建成功且输出 chunk 列表，构建通过。 
- 已执行 `npm run verify:text-encoding`，未发现编码/乱码问题，校验通过。 
- 已执行静态检查 `git diff --check`，无明显格式或空白冲突问题，校验通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41da3d07c48320bc94e5a1ec25d206)