### PR TITLE
fix(客户端注册): 禁止验证码通道关闭时降级注册

### DIFF
--- a/backend/src/services/client-auth.service.ts
+++ b/backend/src/services/client-auth.service.ts
@@ -95,7 +95,7 @@ export interface ClientUpdateProfileInput {
   email?: string
 }
 
-export type ClientValidationMode = 'captcha' | 'verification_code'
+export type ClientValidationMode = 'captcha' | 'verification_code' | 'unavailable'
 
 export interface ClientDepartmentOptionNode {
   id: string
@@ -170,8 +170,8 @@ class ClientAuthService {
         email: emailEnabled,
       },
       registerValidationModes: {
-        mobile: mobileEnabled ? 'verification_code' : 'captcha',
-        email: emailEnabled ? 'verification_code' : 'captcha',
+        mobile: mobileEnabled ? 'verification_code' : 'unavailable',
+        email: emailEnabled ? 'verification_code' : 'unavailable',
       },
       forgotPasswordEnabled: mobileEnabled && emailEnabled,
       departmentTree: departmentConfigs.tree,
@@ -339,6 +339,9 @@ class ClientAuthService {
     if (!account) {
       this.verifyCaptchaIfRequired(input)
       return
+    }
+    if (validationMode === 'unavailable') {
+      throw new BizError(`${account.channel === 'email' ? '邮箱' : '手机'}验证码通道未启用，暂不支持使用该账号注册`, 400)
     }
     if (validationMode === 'verification_code') {
       this.verifyCodeIfRequired(

--- a/src/api/modules/client-auth.ts
+++ b/src/api/modules/client-auth.ts
@@ -54,7 +54,7 @@ export interface ClientVerificationCodeSendResult {
   expireSeconds: number
 }
 
-export type ClientValidationMode = 'captcha' | 'verification_code'
+export type ClientValidationMode = 'captcha' | 'verification_code' | 'unavailable'
 
 export interface ClientDepartmentOptionNode {
   id: string
@@ -146,7 +146,7 @@ export const sendClientVerificationCode = (payload: ClientVerificationCodeSendIn
 
 /**
  * 客户端注册：
- * - 支持图形验证码或短信/邮件验证码。
+ * - 手机/邮箱注册必须使用已启用的短信/邮件验证码，不再允许降级为图形验证码。
  */
 export const clientRegister = (payload: {
   username?: string

--- a/src/views/client/ClientAuthView.vue
+++ b/src/views/client/ClientAuthView.vue
@@ -207,9 +207,10 @@ const registerValidationMode = computed<ClientValidationMode>(() => {
   if (!channel) {
     return 'captcha'
   }
-  return authCapabilities.value?.registerValidationModes[channel] ?? 'captcha'
+  return authCapabilities.value?.registerValidationModes[channel] ?? 'unavailable'
 })
 const registerUsesVerificationCode = computed(() => registerValidationMode.value === 'verification_code')
+const isRegisterChannelUnavailable = computed(() => registerValidationMode.value === 'unavailable')
 const shouldPrepareCaptcha = computed(() => isRegisterMode.value || loginCaptchaVisible.value)
 const isCapabilityHintVisible = computed(() => capabilityLoading.value && !authCapabilities.value)
 const isCapabilityFallbackVisible = computed(() => !capabilityLoading.value && !!capabilityErrorMessage.value && !authCapabilities.value)
@@ -724,8 +725,12 @@ const startRegisterVerificationCountdown = (seconds: number) => {
 }
 
 const handleSendRegisterVerificationCode = async () => {
+  if (isRegisterChannelUnavailable.value) {
+    showAppWarning('当前手机号或邮箱验证码通道未启用，暂不支持注册该账号')
+    return
+  }
   if (!registerUsesVerificationCode.value) {
-    showAppWarning('当前账号类型未启用验证码注册，请根据页面提示使用图片验证码完成注册')
+    showAppWarning('当前账号类型未启用短信/邮箱验证码注册')
     return
   }
   const channel = resolveAccountChannel(registerForm.account)
@@ -895,6 +900,10 @@ const validateDepartmentRegisterFields = () => {
 
 // 注册验证码校验与部门字段校验拆开维护，便于后续继续扩展不同通道策略。
 const validateRegisterChallengeFields = () => {
+  if (isRegisterChannelUnavailable.value) {
+    showAppWarning('当前手机号或邮箱验证码通道未启用，暂不支持注册该账号')
+    return false
+  }
   if (registerUsesVerificationCode.value) {
     if (!registerForm.verificationCode.trim()) {
       showAppWarning('请输入手机/邮箱验证码')
@@ -1067,6 +1076,12 @@ watch(
 )
 
 watch(registerValidationMode, (mode) => {
+  if (mode === 'unavailable') {
+    resetRegisterVerificationTimer()
+    registerForm.verificationCode = ''
+    registerForm.captcha = ''
+    return
+  }
   if (mode !== 'verification_code') {
     resetRegisterVerificationTimer()
     registerForm.verificationCode = ''
@@ -1375,7 +1390,7 @@ onUnmounted(() => {
                   <div class="captcha-row">
                     <el-input
                       v-model="registerForm.captcha"
-                      :placeholder="registerUsesVerificationCode ? '先输入图形验证码，再发送手机/邮箱验证码' : '图形验证码'"
+                      :placeholder="isRegisterChannelUnavailable ? '当前通道暂不支持注册' : registerUsesVerificationCode ? '先输入图形验证码，再发送手机/邮箱验证码' : '图形验证码'"
                       class="geo-input flex-1"
                       size="large"
                       clearable
@@ -1558,7 +1573,7 @@ onUnmounted(() => {
                   <div class="captcha-row">
                     <el-input
                       v-model="registerForm.captcha"
-                      :placeholder="registerUsesVerificationCode ? '先输入图形验证码，再发送手机/邮箱验证码' : '图形验证码'"
+                      :placeholder="isRegisterChannelUnavailable ? '当前通道暂不支持注册' : registerUsesVerificationCode ? '先输入图形验证码，再发送手机/邮箱验证码' : '图形验证码'"
                       class="geo-input flex-1"
                       size="large"
                       clearable


### PR DESCRIPTION
### Motivation
- 修复一个安全回归：当短信/邮箱验证码提供方被禁用时，注册流程被降级为仅需图形验证码（可被解析），导致任意手机号/邮箱可被匿名抢注。 
- 防止默认配置（短信/邮箱均关闭）允许匿名注册并造成账号劫占/占用标识的风险。 

### Description
- 在后端将注册验证模式新增 `unavailable`，不再把“已禁用”的短信/邮箱通道映射为 `captcha`，并在能力声明中返回该状态；修改文件：`backend/src/services/client-auth.service.ts`。 
- 在注册校验流程中，当遇到绑定手机号/邮箱且对应通道为 `unavailable` 时直接拒绝注册请求以避免 CAPTCHA-only 注册绕过所有权校验；修改文件：`backend/src/services/client-auth.service.ts`。 
- 同步更新前端能力类型与提示，使前端能识别 `unavailable` 并在发送验证码或提交注册前阻断与友好提示；修改文件：`src/api/modules/client-auth.ts`、`src/views/client/ClientAuthView.vue`。 
- 保持现有功能与兼容性，未引入新依赖，仅调整校验与前端提示逻辑，修改影响仅限上述三个模块。 

### Testing
- 已执行后端构建 `npm --prefix backend run build`，构建成功（TypeScript 编译通过）。 
- 已执行前端构建 `npm run build`，前端构建成功（Vite 打包完成）。 
- 已执行文本编码校验 `npm run verify:text-encoding`，检查通过（未发现乱码特征）。 
- 已执行后端安全硬化校验 `npm --prefix backend run security:hardening:verify`，脚本通过；执行路由权限契约校验 `npm --prefix backend run task2:route-contract:verify` 失败，失败原因为仓库中若干 reports 路由缺少权限点声明，该项与本次修复无关且需另行处理。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41d0c98bec83208c15d806d4f51f74)