### PR TITLE
fix(security): 隐藏验证码平台敏感模板

### DIFF
--- a/backend/src/routes/system-config.routes.ts
+++ b/backend/src/routes/system-config.routes.ts
@@ -279,7 +279,7 @@ systemConfigRouter.get(
   '/verification-providers',
   requirePermission('system_configs:view'),
   asyncHandler(async (_req, res) => {
-    const data = await systemConfigService.getVerificationProviderConfigs()
+    const data = await systemConfigService.getVerificationProviderConfigs({ maskSensitiveValues: true })
     res.json({
       code: 0,
       message: 'ok',

--- a/backend/src/services/system-config.service.ts
+++ b/backend/src/services/system-config.service.ts
@@ -1739,7 +1739,9 @@ class SystemConfigService {
     })
   }
 
-  async getVerificationProviderConfigs(options: { maskSensitiveValues?: boolean } = {}): Promise<VerificationProviderConfigsResult> {
+  async getVerificationProviderConfigs(
+    options: { maskSensitiveValues?: boolean } = { maskSensitiveValues: true },
+  ): Promise<VerificationProviderConfigsResult> {
     const map = await this.loadVerificationConfigMap()
     return {
       mobile: this.formatVerificationProviderConfig('mobile', map, options),


### PR DESCRIPTION
### Motivation
- 修复管理端接口返回验证码提供商模板（`headersTemplate` / `bodyTemplate`）明文导致低权限 operator 能读取第三方凭据的问题；应对敏感配置进行默认脱敏展示。

### Description
- 将 GET `/api/system-configs/verification-providers` 在路由层显式改为请求脱敏输出：调用 `getVerificationProviderConfigs({ maskSensitiveValues: true })`（文件：`backend/src/routes/system-config.routes.ts`）。
- 将服务层 `getVerificationProviderConfigs` 的默认参数改为脱敏输出，以降低后续调用方遗漏参数时泄露敏感值的风险（文件：`backend/src/services/system-config.service.ts`）。
- 保留已有占位符与保存时保留原值的逻辑，并保留内部调用通过显式 `maskSensitiveValues: false` 获取原文的能力以不破坏发送验证码/保存等内部流程（相关调用处已显式使用 `false`）。
- 变更文件：`backend/src/routes/system-config.routes.ts`，`backend/src/services/system-config.service.ts`。

### Testing
- 已运行构建：`npm --prefix backend run build`，结果：成功（TypeScript 编译通过）。
- 已运行安全硬化检查：`npm --prefix backend run security:hardening:verify`，结果：成功（脚本返回 OK）。
- 已运行路由权限契约验证：`npm --prefix backend run task2:route-contract:verify`，结果：失败（与本次修复无关，失败原因为若干报表路由缺少权限声明：`GET /api/reports/inventory`、`GET /api/reports/tag-sales`、`GET /api/reports/kingdee`、`GET /api/reports/walkin`、`GET /api/reports/outbound-flow`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41d09b58f08320adb905e61038b278)