### PR TITLE
fix: 禁用公开部门账号自助注册以防教职工号被抢占

### DIFF
--- a/backend/src/services/client-auth.service.ts
+++ b/backend/src/services/client-auth.service.ts
@@ -406,30 +406,9 @@ class ClientAuthService {
       }
     }
 
-    const staffNo = this.normalizeStaffNo(input.staffNo)
-    const existedByStaffNo = await this.userRepo.findOne({
-      where: { staffNo },
-      select: ['id'],
-    })
-    if (existedByStaffNo) {
-      throw new BizError('该教职工号已绑定其他账号', 409)
-    }
-
-    const matchedStaff = await this.clientStaffDirectoryRepo.findOne({
-      where: { staffNo, status: 'active' },
-    })
-    if (!matchedStaff) {
-      throw new BizError('教职工号未在学校目录中登记，请联系管理员核验', 409)
-    }
-
-    const usernameValue = this.assertRealName(matchedStaff.realName)
-    const departmentName = await systemConfigService.assertClientDepartmentOption(matchedStaff.departmentName)
-    return {
-      usernameValue,
-      departmentName,
-      staffNo,
-      staffVerified: true,
-    }
+    this.normalizeStaffNo(input.staffNo)
+    // 部门账号绑定的是教职工身份，公开注册无法证明提交者拥有该工号；必须转为管理员核验/开通。
+    throw new BizError('部门账号需由管理员核验身份后开通，请联系管理员处理', 403)
   }
 
   private resolveRegisterVerificationChannel(
@@ -459,32 +438,9 @@ class ClientAuthService {
   }
 
   async lookupStaffDirectoryForRegister(staffNoInput: string): Promise<ClientStaffDirectoryLookupResult> {
-    const staffNo = this.normalizeStaffNo(staffNoInput)
-    const matchedStaff = await this.clientStaffDirectoryRepo.findOne({
-      where: { staffNo, status: 'active' },
-    })
-    if (!matchedStaff) {
-      return {
-        matched: false,
-        staffNo,
-        realName: null,
-        departmentName: null,
-        isRegistered: false,
-      }
-    }
-
-    const existedByStaffNo = await this.userRepo.findOne({
-      where: { staffNo, accountType: 'department' },
-      select: ['id'],
-    })
-
-    return {
-      matched: true,
-      staffNo,
-      realName: matchedStaff.realName,
-      departmentName: matchedStaff.departmentName,
-      isRegistered: Boolean(existedByStaffNo),
-    }
+    this.normalizeStaffNo(staffNoInput)
+    // 安全边界：公开注册页不能按工号反查教职工目录，否则会泄露姓名/部门并帮助攻击者确认可抢占身份。
+    throw new BizError('部门账号需由管理员核验身份后开通，请联系管理员处理', 403)
   }
 
   private async createSessionForUser(user: ClientUser) {

--- a/src/views/client/ClientAuthView.vue
+++ b/src/views/client/ClientAuthView.vue
@@ -105,7 +105,7 @@ const AUTH_MODE_QUERY_TAB_MAP: Record<AuthMode, 'login' | 'register-personal' | 
   'register-personal': 'register-personal',
   'register-department': 'register-department',
 }
-const AUTH_MODE_SEQUENCE: AuthMode[] = ['login', 'register-personal', 'register-department']
+const AUTH_MODE_SEQUENCE: AuthMode[] = ['login', 'register-personal']
 
 interface ClientCaptchaState {
   captchaId: string
@@ -262,10 +262,7 @@ const isCompactLoginLayout = computed(() => {
 // - 兼容历史 `register` 链接，默认回落到个人注册；
 // - 点击顶部切换器后同步刷新当前路由 query，保证刷新与分享链接能恢复正确表单。
 const resolveAuthModeFromQueryTab = (tab: unknown): AuthMode => {
-  if (tab === 'register-department') {
-    return 'register-department'
-  }
-  if (tab === 'register-personal' || tab === 'register') {
+  if (tab === 'register-personal' || tab === 'register' || tab === 'register-department') {
     return 'register-personal'
   }
   return 'login'
@@ -1163,14 +1160,6 @@ onUnmounted(() => {
             >
               个人注册
             </button>
-            <button
-              type="button"
-              class="toggle-btn"
-              :class="{ 'is-active': activeMode === 'register-department' }"
-              @click="switchMode('register-department')"
-            >
-              部门注册
-            </button>
           </div>
 
           <div v-if="successTip" class="success-pill">
@@ -1862,7 +1851,7 @@ onUnmounted(() => {
   position: absolute;
   top: 5px;
   left: 5px;
-  width: calc((100% - 10px) / 3);
+  width: calc((100% - 10px) / 2);
   height: calc(100% - 10px);
   background: #ffffff;
   border-radius: 12px;


### PR DESCRIPTION
### Motivation
- 修复一个高危权限/身份绑定漏洞：匿名注册者可提交 `accountType: "department"` 与任意 `staffNo`，若目录存在即被标记为已核验并获得会话，从而可冒用教职工身份并下部门 O2O 订单。 
- 需要在最小改动范围内阻断该自助流程并避免泄露员工目录 PII 与支持工号枚举的公开查询接口。 

### Description
- 在服务层禁止公开注册直接绑定部门账号：`backend/src/services/client-auth.service.ts` 中的部门注册路径改为只校验工号格式并返回 403，提示需管理员核验以开通部门账号。 
- 禁止公开按工号反查教职工目录：`lookupStaffDirectoryForRegister` 现在不再返回姓名/部门/注册状态以避免信息泄露与枚举辅助。 
- 移除客户端认证页的“部门注册”公开入口并调整切换器与样式以维持页面布局：`src/views/client/ClientAuthView.vue` 已移除部门注册按钮并使历史 `register-department` 链接回落到个人注册。 
- 变更保持最小化，不引入新依赖或放宽现有校验逻辑，所有阻断均在服务层返回明确 403，便于后续引入管理员审批或邀请机制。 

### Testing
- 已运行后端类型/构建检查：`npm --prefix backend run build`，结果成功并通过 TypeScript 检查。 
- 已运行前端构建：`npm run build`，前端打包成功（Vite 构建完成）。 
- 已运行文本编码验证：`npm run verify:text-encoding`，未发现编码问题。 
- 已运行安全加固验证脚本：`npm --prefix backend run security:hardening:verify`，脚本全部检查通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41ab214a988320866fe83e3283f106)