### PR TITLE
fix: 迁移恢复异常后恢复 O2O 超时回收

### DIFF
--- a/backend/scripts/database-migration-foundation-verify.ts
+++ b/backend/scripts/database-migration-foundation-verify.ts
@@ -25,6 +25,31 @@ import {
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'y-link-db-migration-foundation-'))
 
 try {
+  const backendIndexSource = fs.readFileSync(path.resolve(import.meta.dirname, '../src/index.ts'), 'utf8')
+  const resumeCallIndex = backendIndexSource.indexOf(
+    'databaseMigrationService.resumeInterruptedAutomaticMigrationAfterStartup()',
+  )
+  const resumeChainSource = backendIndexSource.slice(resumeCallIndex, resumeCallIndex + 1_500)
+  const catchIndex = resumeChainSource.indexOf('.catch(')
+  const finallyIndex = resumeChainSource.indexOf('.finally(')
+  const readOnlyGuardIndex = resumeChainSource.indexOf(
+    'if (!databaseMaintenanceModeService.isReadOnly())',
+  )
+  const timeoutRecycleStartIndex = resumeChainSource.indexOf(
+    'o2oPreorderService.startTimeoutRecycleLoop()',
+  )
+  assert.ok(resumeCallIndex >= 0, '启动入口必须恢复意外中断的自动迁移任务')
+  assert.ok(catchIndex >= 0, '自动迁移恢复异常必须记录并收敛')
+  assert.ok(finallyIndex > catchIndex, '自动迁移恢复成功或失败后都必须进入统一后台任务恢复分支')
+  assert.ok(
+    readOnlyGuardIndex > finallyIndex,
+    '后台任务恢复必须在 finally 中复核数据库只读维护状态',
+  )
+  assert.ok(
+    timeoutRecycleStartIndex > readOnlyGuardIndex,
+    '非只读状态下必须在统一恢复分支启动 O2O 超时回收',
+  )
+
   const paths = resolveAppDataPaths(tempRoot)
   assert.equal(paths.rootDir, path.resolve(tempRoot))
   assert.equal(paths.databaseMigrationDir, path.join(path.resolve(tempRoot), 'database-migration'))

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -379,13 +379,14 @@ async function bootstrap(): Promise<void> {
     if (taskId) {
       logLine('DB MIGRATION', `task=${taskId} 已调度自动续跑`, 'warn')
     }
+  }).catch((error) => {
+    console.error(paint('[y-link-backend] resume automatic database migration failed:', 'red'), error)
+  }).finally(() => {
     if (!databaseMaintenanceModeService.isReadOnly()) {
       o2oPreorderService.startTimeoutRecycleLoop()
     } else {
       logLine('DB MIGRATION', '数据库仍处于只读维护，后台写任务保持暂停', 'warn')
     }
-  }).catch((error) => {
-    console.error(paint('[y-link-backend] resume automatic database migration failed:', 'red'), error)
   })
 }
 


### PR DESCRIPTION
## 变更摘要

- 将自动数据库迁移启动恢复链路的后台任务恢复判断移入 `finally`。
- 无论 `resumeInterruptedAutomaticMigrationAfterStartup()` 成功或抛错，都会重新检查只读维护状态。
- 非只读时启动 O2O 超时订单回收；仍处于只读维护时继续暂停后台写任务。
- 在数据库迁移 foundation 验证中增加启动链路静态契约，防止异常分支再次漏启超时回收。

## 修复原因

此前 O2O 超时回收只在迁移恢复 Promise 的成功分支启动。当启动期恢复在进入只读维护前失败时，服务虽然可继续运行且并非只读，但本次进程生命周期内不会启动超时回收，可能造成超时订单与预占库存长期不释放。

## 验证结果

- `npm --prefix backend run verify:db:migration:foundation`
- `npm --prefix backend run build`
- `npm run verify:text-encoding`
- `npm run verify:onebox:smoke`
- `git diff --check`

以上检查均已通过。

## 风险与回滚

- 本次只调整启动恢复 Promise 的收尾位置，不改变迁移状态机、接口或数据结构。
- 只读状态仍不会启动后台写任务，保持 fail-closed 行为。
- 如需回滚，可 revert 本 PR 的合并提交。