### PR TITLE
修复后端依赖审计告警

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4577,9 +4577,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -70,7 +70,7 @@
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "ip-address": "^10.2.0",
     "node-gyp": "^12.3.0",
     "tar": "^7.5.19",


### PR DESCRIPTION
## 修复内容

- 将 `brace-expansion` override 从 5.0.8 升级到官方修复版 5.0.9
- 将锁文件中的间接依赖 `undici` 从 6.27.0 升级到官方修复版 6.28.0
- 未引入其他依赖升级或业务代码改动

## 根因

后端依赖清单锁定在新公告标记的受影响版本，导致 `npm audit --audit-level=high` 失败，并使后续数据库并发验收被 CI 跳过。

## 验证

- `npm ci`：通过
- 根目录与后端 `npm audit --audit-level=high`：均为 0 vulnerabilities
- `npm --prefix backend run build`：通过
- 报表中心契约验证：通过
- ExcelJS 工作簿生成与读取回归：通过
- `git diff --check`：通过
