### PR TITLE
fix: 串行化 SQLite 写事务，修复并发提交失败

### DIFF
--- a/backend/scripts/task8-verify.ts
+++ b/backend/scripts/task8-verify.ts
@@ -6,12 +6,10 @@
  * - 数据源相关模块必须用 `await import()` 动态加载：ESM 的静态 import 会在模块体执行前完成求值，
  *   若改回静态 import，下面这几行 process.env 赋值就会晚于 env.ts / data-source.ts 的初始化而完全失效，
  *   脚本会连到开发者的默认库 data/y-link.sqlite 上跑，既污染本地数据、又会因残留数据在重跑时报错。
- *
- * 已知未决问题：`verifyConcurrentSerialAndDrilldown` 目前在 SQLite 下无法通过。
- * TypeORM 的 sqlite 驱动只持有一条连接，16 个并发 `orderService.submit` 的写事务会在这条连接上重叠，
- * 先报 `cannot start a transaction within a transaction`、退避重试后又报 `no such savepoint`。
- * 这不是本脚本的问题，而是"SQLite 部署下并发写事务"这一production 缺陷的暴露：
- * 要真正修好需要把全部 80 处 `AppDataSource.transaction(...)` 收口到一个串行化入口，属于独立改造。
+ * - `verifyConcurrentSerialAndDrilldown` 是 SQLite 并发写事务串行化（issue #36）的回归守卫：
+ *   它并发提交 16 笔出库单，若哪天写事务绕过了 `runInTransaction` 闸门、直接调用
+ *   `AppDataSource.transaction`，这一项就会重新报
+ *   `cannot start a transaction within a transaction` 或 `no such savepoint`。
  */
 
 import 'reflect-metadata'
@@ -245,14 +243,17 @@ const verifyConcurrentSerialAndDrilldown = async () => {
   assert.equal(productDrilldown.records.length >= 1, true)
   assert.equal(productDrilldown.records.every((record) => record.orderType === 'walkin'), true)
 
+  // 看板的"客户"维度取的是申请部门（`COALESCE(NULLIF(TRIM(customerDepartmentName), ''), '散客')`），
+  // 散客单没有部门、统一归到 `散客` 这一个桶里——不是按订单的 customerName 逐个成桶。
+  // 因此这里要按桶名 `散客` 下钻，早先按 `散客1` 查是查不到任何记录的。
   const customerDrilldown = await dashboardService.getCustomerRankDrilldown({
-    customerName: '散客1',
+    customerName: '散客',
     startDate: todayText,
     endDate: todayText,
     orderType: 'walkin',
   })
   assert.equal(customerDrilldown.records.length >= 1, true)
-  assert.equal(customerDrilldown.records[0]?.showNo.startsWith('hyyz'), true)
+  assert.equal(customerDrilldown.records.every((record) => record.showNo.startsWith('hyyz')), true)
 
   const tagAggregate = await dashboardService.getTagAggregate({
     tagId: analyticsTag.id,

--- a/backend/src/config/transaction-runner.ts
+++ b/backend/src/config/transaction-runner.ts
@@ -1,0 +1,71 @@
+/**
+ * 模块说明：backend/src/config/transaction-runner.ts
+ * 文件职责：为全库写事务提供统一入口，并在 SQLite 方言下把并发写事务串行化。
+ * 实现逻辑：
+ * - TypeORM 的 sqlite 驱动只持有**一条**连接，`AppDataSource.transaction()` 的 BEGIN/COMMIT 也走这条连接。
+ *   Node 的异步调度会让两个事务的语句交错，于是后进入的 `BEGIN TRANSACTION` 撞上尚未提交的事务，
+ *   直接抛 `SQLITE_ERROR: cannot start a transaction within a transaction`；
+ *   即便绕过这一步（TypeORM 检测到活跃事务后改用 SAVEPOINT），交错也会让 savepoint 栈的
+ *   进出顺序错乱而抛 `no such savepoint`。这类错误无法靠重试自愈——一旦交错发生，栈本身已经乱了，
+ *   因此唯一可靠的解法是让写事务排队，一次只跑一个。
+ * - MySQL 走连接池，每个事务独占一条连接，本就不存在该问题，因此这里直接透传，不引入任何额外排队。
+ * 维护说明：
+ * - **新增写事务一律用 `runInTransaction`，不要直接调用 `AppDataSource.transaction`**，
+ *   否则该事务会绕过闸门，重新引入上述并发失败；
+ * - 闸门带重入放行（见 `transactionDepth`）：事务体内若再次进入本函数，直接执行而不排队，
+ *   避免"外层持锁、内层排队"造成自死锁。现有代码遵循"事务内调用下游方法时透传 manager"的约定、
+ *   实测无嵌套，这里的重入放行是给未来新代码兜底的，不是常规路径。
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { EntityManager } from 'typeorm'
+import { AppDataSource } from './data-source.js'
+
+/** 记录当前异步上下文所处的事务嵌套深度，用于重入放行判断。 */
+const transactionDepth = new AsyncLocalStorage<number>()
+
+/**
+ * SQLite 串行化队列：始终指向"最后一个入队任务"的 promise。
+ * 新任务挂在它后面，从而保证同一时刻只有一个写事务在跑。
+ * 两个分支都用 `() => run()`（成功和失败都继续），避免前一个事务失败后整条链被永久拒绝。
+ */
+let sqliteWriteQueue: Promise<unknown> = Promise.resolve()
+
+const isSqlite = (): boolean => AppDataSource.options.type === 'sqlite'
+
+/**
+ * 统一的写事务入口。
+ *
+ * @param runInManager 事务体，收到的 `manager` 必须透传给所有下游调用，
+ *                     不要在其中直接使用 `AppDataSource.getRepository(...)`——那会走另一条连接、
+ *                     读不到本事务未提交的数据。
+ */
+export async function runInTransaction<T>(
+  runInManager: (manager: EntityManager) => Promise<T>,
+): Promise<T> {
+  const execute = () => AppDataSource.transaction(runInManager)
+
+  if (!isSqlite()) {
+    return execute()
+  }
+
+  const depth = transactionDepth.getStore() ?? 0
+  if (depth > 0) {
+    // 已经在闸门内：再排队会等一个永远不会结束的自己。
+    return execute()
+  }
+
+  const runWithDepth = () => transactionDepth.run(depth + 1, execute)
+  const scheduled = sqliteWriteQueue.then(runWithDepth, runWithDepth)
+  // 队列本身只用于排序，必须吞掉结果与异常，否则一次失败会毒化后续所有事务。
+  sqliteWriteQueue = scheduled.then(() => undefined, () => undefined)
+  return scheduled
+}
+
+/**
+ * 仅供测试与诊断：等待当前排队中的 SQLite 写事务全部结束。
+ * 业务代码不需要调用它。
+ */
+export async function waitForPendingWriteTransactions(): Promise<void> {
+  await sqliteWriteQueue
+}

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -8,6 +8,7 @@
 
 import { LessThan, MoreThan } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { env } from '../config/env.js'
 import { resolvePermissionsByRole } from '../constants/auth-permissions.js'
 import { SysUser } from '../entities/sys-user.entity.js'
@@ -165,7 +166,7 @@ export class AuthService {
     const expiresAt = new Date(now.getTime() + env.AUTH_TOKEN_TTL_HOURS * 60 * 60 * 1000)
     const token = generateSessionToken()
 
-    const data = await AppDataSource.transaction(async (manager) => {
+    const data = await runInTransaction(async (manager) => {
       const sessionRepo = manager.getRepository(SysUserSession)
       const userRepo = manager.getRepository(SysUser)
 
@@ -218,7 +219,7 @@ export class AuthService {
   }
 
   async logout(auth: AuthUserContext, requestMeta?: RequestMeta): Promise<void> {
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       const sessionRepo = manager.getRepository(SysUserSession)
       const sessionTokenHash = hashSessionToken(auth.sessionToken)
       const existedSession = await sessionRepo.findOne({
@@ -317,7 +318,7 @@ export class AuthService {
       throw new BizError('当前密码错误', 400)
     }
 
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(SysUser)
       const sessionRepo = manager.getRepository(SysUserSession)
 

--- a/backend/src/services/client-auth.service.ts
+++ b/backend/src/services/client-auth.service.ts
@@ -8,6 +8,7 @@
 
 import { LessThan, type EntityManager } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { env } from '../config/env.js'
 import { ClientStaffDirectory } from '../entities/client-staff-directory.entity.js'
 import { CLIENT_USER_ACCOUNT_TYPES, ClientUser, type ClientUserAccountType } from '../entities/client-user.entity.js'
@@ -563,7 +564,7 @@ class ClientAuthService {
     const now = new Date()
     const expiresAt = new Date(now.getTime() + env.AUTH_TOKEN_TTL_HOURS * 60 * 60 * 1000)
     const token = generateSessionToken()
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       await manager.getRepository(ClientUserSession).delete({ expiresAt: LessThan(now) })
       user.lastLoginAt = now
       await manager.getRepository(ClientUser).save(user)
@@ -606,7 +607,7 @@ class ClientAuthService {
   }
 
   private async guardStaffInviteAttempt(staffNo: string, inviteCode: string, requestMeta?: RequestMeta) {
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const record = await this.buildLockedDirectoryQuery(manager, staffNo).getOne()
       const now = new Date()
       if (this.isUsableStaffInvite(record, inviteCode, now)) return true
@@ -662,7 +663,7 @@ class ClientAuthService {
     try {
       const passwordHash = await hashPassword(password)
       user = isTeacherRegister
-        ? await AppDataSource.transaction(async (manager) => {
+        ? await runInTransaction(async (manager) => {
           const directory = await this.buildLockedDirectoryQuery(manager, registerProfile.staffNo ?? '').getOne()
           const now = new Date()
           if (!directory || !this.isUsableStaffInvite(directory, input.inviteCode ?? '', now)) throw new BizError('工号或邀请码无效', 400)
@@ -833,7 +834,7 @@ class ClientAuthService {
       throw new BizError('用户不存在', 404)
     }
     user.passwordHash = await hashPassword(newPassword)
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       await manager.getRepository(ClientUser).save(user)
       await manager.getRepository(ClientUserSession).delete({ userId: user.id })
     })
@@ -915,7 +916,7 @@ class ClientAuthService {
     const newPassword = assertClientPasswordPolicy(input.newPassword, '新密码')
 
     user.passwordHash = await hashPassword(newPassword)
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       await manager.getRepository(ClientUser).save(user)
       await manager.getRepository(ClientUserSession).delete({ userId: user.id })
     })

--- a/backend/src/services/client-feedback.service.ts
+++ b/backend/src/services/client-feedback.service.ts
@@ -12,6 +12,7 @@
 
 import { In, LessThan, type EntityManager } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { resolvePermissionsByRole } from '../constants/auth-permissions.js'
 import {
   ClientFeedbackConversation,
@@ -972,7 +973,7 @@ class ClientFeedbackService {
     let lastError: unknown
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       try {
-        result = await AppDataSource.transaction(async (manager) => {
+        result = await runInTransaction(async (manager) => {
           const conversationRepo = manager.getRepository(ClientFeedbackConversation)
           const conversation = await conversationRepo.save(
             conversationRepo.create({
@@ -1133,7 +1134,7 @@ class ClientFeedbackService {
       }
     }
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireOwnedConversation(id, clientAuth, manager)
       const readChanged = await this.markConversationReadForClient(manager, conversation)
       const messages = (await this.loadConversationMessages(manager, conversation.id))
@@ -1169,7 +1170,7 @@ class ClientFeedbackService {
     const attachments = this.normalizeAttachments(input.attachments)
     const clientSnapshot = await this.getClientUserSnapshot(clientAuth.userId)
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireOwnedConversation(id, clientAuth, manager)
       if (conversation.status === 'closed') {
         throw new BizError('当前反馈会话已关闭，请新建反馈后继续沟通', 400)
@@ -1237,7 +1238,7 @@ class ClientFeedbackService {
   ) {
     const clientSnapshot = await this.getClientUserSnapshot(clientAuth.userId)
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireOwnedConversation(id, clientAuth, manager)
       if (conversation.status === 'closed') {
         return {
@@ -1314,7 +1315,7 @@ class ClientFeedbackService {
   ) {
     const clientSnapshot = await this.getClientUserSnapshot(clientAuth.userId)
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireOwnedConversation(id, clientAuth, manager)
       if (conversation.status === 'closed') {
         return {
@@ -1397,7 +1398,7 @@ class ClientFeedbackService {
       CLIENT_FEEDBACK_SATISFACTION_COMMENT_MAX_LENGTH,
     )
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireOwnedConversation(id, clientAuth, manager)
       if (conversation.status !== 'resolved' && conversation.status !== 'closed') {
         throw new BizError('当前反馈单尚未进入可评价阶段', 400)
@@ -1522,7 +1523,7 @@ class ClientFeedbackService {
       }
     }
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireConversationById(id, manager)
       const readChanged = await this.markConversationReadForService(manager, conversation)
       const messages = await this.loadConversationMessages(manager, conversation.id)
@@ -1553,7 +1554,7 @@ class ClientFeedbackService {
     const content = this.normalizeMessageContent(input.content)
     const attachments = this.normalizeAttachments(input.attachments)
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireConversationById(id, manager)
       if (conversation.status === 'closed') {
         throw new BizError('当前反馈会话已关闭，请先重新打开后再回复', 400)
@@ -1616,7 +1617,7 @@ class ClientFeedbackService {
       throw new BizError('反馈会话状态非法', 400)
     }
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireConversationById(id, manager)
       this.ensureConversationOwnedByActor(conversation, actor)
       if (conversation.status === input.status) {
@@ -1717,7 +1718,7 @@ class ClientFeedbackService {
     requestMeta?: RequestMeta,
   ) {
     const targetUserId = input.assigneeUserId.trim()
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireConversationById(id, manager)
       const targetUser = await this.requireAssignableServiceUser(targetUserId, manager)
       const beforeAssignee = {
@@ -1836,7 +1837,7 @@ class ClientFeedbackService {
     actor: AuthUserContext,
     requestMeta?: RequestMeta,
   ) {
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireConversationById(id, manager)
       const before = this.buildConversationFields(conversation)
       const subjectBefore = conversation.subject
@@ -1941,7 +1942,7 @@ class ClientFeedbackService {
       CLIENT_FEEDBACK_INTERNAL_REMARK_MAX_LENGTH,
     )
 
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const conversation = await this.requireConversationById(id, manager)
       const before = this.buildInternalRemarkView(conversation)
       const beforeContent = before?.content ?? null

--- a/backend/src/services/client-staff-directory.service.ts
+++ b/backend/src/services/client-staff-directory.service.ts
@@ -6,6 +6,7 @@
  * 3. 目录状态变化后会批量同步已绑定的部门账号实名校验状态，保证历史账号数据与目录口径一致。
  */
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import ExcelJS from 'exceljs'
 import {
   CLIENT_STAFF_DIRECTORY_STATUSES,
@@ -776,7 +777,7 @@ export class ClientStaffDirectoryService {
     const status = this.normalizeStatus(input.status)
     const departmentName = await systemConfigService.assertClientDepartmentOption(input.departmentName)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       await this.assertUniqueStaffNo(manager, staffNo)
       const repo = manager.getRepository(ClientStaffDirectory)
       const entity = repo.create({
@@ -819,7 +820,7 @@ export class ClientStaffDirectoryService {
     const realName = this.normalizeRealName(input.realName)
     const departmentName = await systemConfigService.assertClientDepartmentOption(input.departmentName)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(ClientStaffDirectory)
       const record = await repo.findOne({ where: { id } })
       if (!record) {
@@ -872,7 +873,7 @@ export class ClientStaffDirectoryService {
     requestMeta?: RequestMeta,
   ): Promise<{ record: ClientStaffDirectoryRecord }> {
     const status = this.normalizeStatus(input.status)
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(ClientStaffDirectory)
       const record = await repo.findOne({ where: { id } })
       if (!record) {
@@ -912,7 +913,7 @@ export class ClientStaffDirectoryService {
     requestMeta?: RequestMeta,
   ): Promise<{ record: ClientStaffDirectoryRecord }> {
     const inviteCode = normalizeStaffInviteCode(inviteCodeInput)
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(ClientStaffDirectory)
       const record = await repo.findOne({ where: { id } })
       if (!record) throw new BizError('教职工目录记录不存在', 404)
@@ -955,7 +956,7 @@ export class ClientStaffDirectoryService {
   }
 
   async disableInviteCode(id: string, actor: AuthUserContext, requestMeta?: RequestMeta) {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(ClientStaffDirectory)
       const record = await repo.findOne({ where: { id } })
       if (!record) throw new BizError('教职工目录记录不存在', 404)
@@ -989,7 +990,7 @@ export class ClientStaffDirectoryService {
       throw new BizError('请先选择要删除的教职工目录记录', 400)
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(ClientStaffDirectory)
       const records = await repo.find({
         where: {
@@ -1084,7 +1085,7 @@ export class ClientStaffDirectoryService {
     list: ClientStaffDirectoryRecord[]
   }> {
     const rows = await this.resolveImportDepartmentRows(this.normalizeImportRows(input))
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(ClientStaffDirectory)
       const resolvedRows = rows
       const existingMap = await this.loadExistingByStaffNos(manager, resolvedRows.map((item) => item.staffNo))

--- a/backend/src/services/client-user-manage.service.ts
+++ b/backend/src/services/client-user-manage.service.ts
@@ -7,6 +7,7 @@
  */
 
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import {
   CLIENT_USER_ACCOUNT_TYPES,
   CLIENT_USER_STATUSES,
@@ -241,7 +242,7 @@ export class ClientUserManageService {
       staffVerified = true
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(ClientUser)
 
       if (profileKind === 'teacher') {
@@ -400,7 +401,7 @@ export class ClientUserManageService {
       throw new BizError('客户端用户状态非法', 400)
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(ClientUser)
       const sessionRepo = manager.getRepository(ClientUserSession)
       const user = await userRepo.findOne({ where: { id } })
@@ -457,7 +458,7 @@ export class ClientUserManageService {
     const email = this.normalizeEmail(input.email)
     const departmentName = await systemConfigService.assertClientDepartmentOption(input.departmentName)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(ClientUser)
       const sessionRepo = manager.getRepository(ClientUserSession)
       const user = await userRepo.findOne({ where: { id } })
@@ -533,7 +534,7 @@ export class ClientUserManageService {
       throw new BizError('新密码不能为空', 400)
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(ClientUser)
       const sessionRepo = manager.getRepository(ClientUserSession)
       const user = await userRepo

--- a/backend/src/services/data-maintenance.service.ts
+++ b/backend/src/services/data-maintenance.service.ts
@@ -10,6 +10,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { resolveSqliteDatabasePath } from '../config/database-bootstrap.js'
 import { env } from '../config/env.js'
 import { BaseProduct } from '../entities/base-product.entity.js'
@@ -164,7 +165,7 @@ class DataMaintenanceService {
     const adminActor = await this.assertAdminActor(actor, requestMeta, 'data_maintenance.import_json', '导入 JSON 数据')
     const normalizedPayload = validateExportPayload(payload)
     const importSummary: ImportSummary = buildImportSummary(normalizedPayload)
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       await manager.getRepository(InventoryLog).clear()
       await manager.getRepository(O2oPreorderItem).clear()
       await manager.getRepository(O2oPreorder).clear()

--- a/backend/src/services/inbound.service.ts
+++ b/backend/src/services/inbound.service.ts
@@ -7,6 +7,7 @@
 import { randomUUID } from 'node:crypto'
 import { Brackets, In, type EntityManager } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { BaseProduct } from '../entities/base-product.entity.js'
 import { BaseProductSku } from '../entities/base-product-sku.entity.js'
 import { BizInboundOrder } from '../entities/biz-inbound-order.entity.js'
@@ -254,7 +255,7 @@ class InboundService {
     this.assertSupplierActor(actor)
     const normalizedItems = this.normalizeSupplierInboundItems(input.items)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const productIds = [...new Set(normalizedItems.map((item) => item.productId))]
       const productMap = await this.loadActiveProductsByIds(productIds, manager)
       const resolvedItems = await this.resolveInboundItemsWithSku(normalizedItems, productMap, manager)
@@ -318,7 +319,7 @@ class InboundService {
   async updateSupplierDelivery(actor: AuthUserContext, orderId: string, input: UpdateSupplierInboundInput, requestMeta?: RequestMeta) {
     const normalizedItems = this.normalizeSupplierInboundItems(input.items)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const order = await this.findSupplierMutableOrder(orderId, actor, '改单', manager)
       const productIds = [...new Set(normalizedItems.map((item) => item.productId))]
       const productMap = await this.loadActiveProductsByIds(productIds, manager)
@@ -378,7 +379,7 @@ class InboundService {
       throw new BizError('请填写撤销原因', 400)
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const order = await this.findSupplierMutableOrder(orderId, actor, '撤销', manager)
       const items = await manager.getRepository(BizInboundOrderItem).find({ where: { orderId: order.id } })
 
@@ -414,7 +415,7 @@ class InboundService {
   }
 
   async softDeleteSupplierDelivery(actor: AuthUserContext, orderId: string, requestMeta?: RequestMeta) {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const order = await this.findSupplierOwnedOrder(orderId, actor, manager)
       if (this.isDeleted(order)) {
         throw new BizError(`送货单“${order.showNo}”已删除，请勿重复删除`, 409)
@@ -451,7 +452,7 @@ class InboundService {
   }
 
   async restoreSupplierDelivery(actor: AuthUserContext, orderId: string, requestMeta?: RequestMeta) {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const order = await this.findSupplierOwnedOrder(orderId, actor, manager)
       if (!this.isDeleted(order)) {
         throw new BizError(`送货单“${order.showNo}”未删除，无需恢复`, 409)
@@ -488,7 +489,7 @@ class InboundService {
   }
 
   async purgeSupplierDelivery(actor: AuthUserContext, orderId: string, confirmShowNo?: string, requestMeta?: RequestMeta) {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const order = await this.findSupplierOwnedOrder(orderId, actor, manager)
       if (!this.isDeleted(order)) {
         throw new BizError(`送货单“${order.showNo}”未删除，请先删除后再永久删除`, 409)
@@ -528,7 +529,7 @@ class InboundService {
     this.assertAdminInboundActor(actor)
     const normalizedItems = this.normalizeSupplierInboundItems(input.items)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const normalizedOrderId = String(orderId).trim()
       if (!normalizedOrderId) {
         throw new BizError('送货单不存在', 404)
@@ -748,7 +749,7 @@ class InboundService {
     if (!normalizedCode) {
       throw new BizError('核销码不能为空', 400)
     }
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const order = await manager.getRepository(BizInboundOrder).findOne({
         where: { verifyCode: normalizedCode },
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -1,6 +1,7 @@
 import { createHmac } from 'node:crypto'
 import { In, MoreThan, type EntityManager } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import {
   NotificationRule,
   NOTIFICATION_EXTERNAL_TRIGGER_MODES,
@@ -503,7 +504,7 @@ export class NotificationService {
     }
 
     let changed = false
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       const txRuleRepo = manager.getRepository(NotificationRule)
       const txSystemConfigRepo = manager.getRepository(SystemConfig)
       await this.ensureOnlineWindowConfig(manager)

--- a/backend/src/services/o2o-preorder.service.ts
+++ b/backend/src/services/o2o-preorder.service.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from 'node:crypto'
 import { Brackets, type EntityManager, In, LessThanOrEqual, Not } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { BaseProduct } from '../entities/base-product.entity.js'
 import { BaseProductSku } from '../entities/base-product-sku.entity.js'
 import { RelProductTag } from '../entities/rel-product-tag.entity.js'
@@ -1926,7 +1927,7 @@ class O2oPreorderService {
     const normalizedIsSystemApplied = Boolean(input.isSystemApplied)
 
     const o2oRules = await systemConfigService.getO2oRuleConfigs()
-    const detail = await AppDataSource.transaction(async (manager) => {
+    const detail = await runInTransaction(async (manager) => {
       const clientUser = await manager.getRepository(ClientUser).findOne({
         where: { id: auth.userId },
         select: ['id', 'realName', 'accountType', 'departmentName', 'staffNo'],
@@ -2342,7 +2343,7 @@ class O2oPreorderService {
     const normalizedRemark = this.normalizePreorderRemark(input.remark)
     const o2oRules = await systemConfigService.getO2oRuleConfigs()
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(O2oPreorder)
       const orderItemRepo = manager.getRepository(O2oPreorderItem)
 
@@ -2427,7 +2428,7 @@ class O2oPreorderService {
     const normalizedRemark = this.normalizePreorderRemark(input.remark)
     const o2oRules = await systemConfigService.getO2oRuleConfigs()
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(O2oPreorder)
       const orderItemRepo = manager.getRepository(O2oPreorderItem)
       const order = await orderRepo.findOne({
@@ -2609,7 +2610,7 @@ class O2oPreorderService {
         throw new BizError('退货数量必须为正整数', 400)
       }
     })
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(O2oPreorder)
       const order = await orderRepo.findOne({
         where: { id: orderId, clientUserId: auth.userId, isDeleted: false },
@@ -2798,7 +2799,7 @@ class O2oPreorderService {
 
   async markCustomerOrderPrintedByClient(auth: ClientAuthContext, orderId: string) {
     await this.cancelTimeoutOrders()
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(O2oPreorder)
       const order = await orderRepo.findOne({
         where: { id: orderId, clientUserId: auth.userId, isDeleted: false },
@@ -2823,7 +2824,7 @@ class O2oPreorderService {
     if (typeof input.hasCustomerOrder !== 'boolean' && typeof input.isSystemApplied !== 'boolean') {
       throw new BizError('请至少传入一个可更新字段', 400)
     }
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(O2oPreorder)
       const order = await orderRepo.findOne({
         where: { id: input.orderId, isDeleted: false },
@@ -2860,7 +2861,7 @@ class O2oPreorderService {
       throw new BizError('请填写订单号完成二次确认', 400)
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const preorderRepo = manager.getRepository(O2oPreorder)
       const preorderItemRepo = manager.getRepository(O2oPreorderItem)
       const returnRequestRepo = manager.getRepository(O2oReturnRequest)
@@ -2961,7 +2962,7 @@ class O2oPreorderService {
 
   async cancelMyOrder(auth: ClientAuthContext, id: string) {
     await this.cancelTimeoutOrders()
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       const order = await manager.getRepository(O2oPreorder).findOne({
         where: { id, isDeleted: false },
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },
@@ -3213,7 +3214,7 @@ class O2oPreorderService {
 
   async rejectReturnRequest(input: RejectReturnRequestInput, actor: AuthUserContext) {
     const normalizedRejectReason = this.normalizeReturnRejectReason(input.rejectReason)
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const returnRequestRepo = manager.getRepository(O2oReturnRequest)
       const orderRepo = manager.getRepository(O2oPreorder)
       const returnRequest = await returnRequestRepo.findOne({
@@ -3351,7 +3352,7 @@ class O2oPreorderService {
   async verifyByCode(verifyCode: string, actor: AuthUserContext) {
     const normalizedVerifyCode = this.normalizeVerifyCode(verifyCode)
     await this.cancelTimeoutOrders()
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const returnRequest = await manager.getRepository(O2oReturnRequest).findOne({
         where: { verifyCode: normalizedVerifyCode },
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },
@@ -3381,7 +3382,7 @@ class O2oPreorderService {
     if (!Number.isInteger(normalizedQty) || normalizedQty <= 0) {
       throw new BizError('入库数量必须为正整数', 400)
     }
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const product = await manager.getRepository(BaseProduct).findOne({
         where: { id: productId },
         lock: manager.connection.options.type === 'sqlite' ? undefined : { mode: 'pessimistic_write' },
@@ -3510,7 +3511,7 @@ class O2oPreorderService {
           if (!timeoutOrders.length) {
             break
           }
-          await AppDataSource.transaction(async (manager) => {
+          await runInTransaction(async (manager) => {
             for (const order of timeoutOrders) {
               const cancelled = await this.cancelTimedOutOrderInManager(manager, order)
               if (cancelled) {

--- a/backend/src/services/order-serial.service.ts
+++ b/backend/src/services/order-serial.service.ts
@@ -8,6 +8,7 @@
 
 import type { EntityManager } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { BizOutboundOrder } from '../entities/biz-outbound-order.entity.js'
 import { O2oPreorder } from '../entities/o2o-preorder.entity.js'
 import { SystemConfig } from '../entities/system-config.entity.js'
@@ -71,7 +72,7 @@ class OrderSerialService {
     let lastError: unknown
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       try {
-        return await AppDataSource.transaction(async (transactionManager) =>
+        return await runInTransaction(async (transactionManager) =>
           this.generateOrderNoWithManager(normalizedOrderType, transactionManager),
         )
       } catch (error) {
@@ -102,7 +103,7 @@ class OrderSerialService {
       return this.rollbackCurrentIfMatchesWithManager(normalizedOrderType, showNo, manager)
     }
 
-    return AppDataSource.transaction((transactionManager) =>
+    return runInTransaction((transactionManager) =>
       this.rollbackCurrentIfMatchesWithManager(normalizedOrderType, showNo, transactionManager),
     )
   }
@@ -117,7 +118,7 @@ class OrderSerialService {
       return this.recalibrateCurrentFromOccupancyWithManager(normalizedOrderType, manager)
     }
 
-    return AppDataSource.transaction((transactionManager) =>
+    return runInTransaction((transactionManager) =>
       this.recalibrateCurrentFromOccupancyWithManager(normalizedOrderType, transactionManager),
     )
   }

--- a/backend/src/services/order.service.ts
+++ b/backend/src/services/order.service.ts
@@ -9,6 +9,7 @@
  */
 
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { Brackets, type EntityManager } from 'typeorm'
 import { BizOutboundOrder } from '../entities/biz-outbound-order.entity.js'
 import { BizOutboundOrderItem } from '../entities/biz-outbound-order-item.entity.js'
@@ -347,7 +348,7 @@ export class OrderService {
       throw new BizError('请填写业务单号完成二次确认')
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(BizOutboundOrder)
       const order = await orderRepo.findOne({ where: { id } })
       if (!order) {
@@ -401,7 +402,7 @@ export class OrderService {
    * - 保留主单与明细原始数据，恢复后可继续查询与查看详情。
    */
   async restoreById(id: string, actor: AuthUserContext, requestMeta?: RequestMeta): Promise<OrderSummaryView> {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(BizOutboundOrder)
       const order = await orderRepo.findOne({ where: { id } })
       if (!order) {
@@ -462,7 +463,7 @@ export class OrderService {
       throw new BizError('请填写业务单号完成二次确认')
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const orderRepo = manager.getRepository(BizOutboundOrder)
       const order = await orderRepo.findOne({ where: { id } })
       if (!order) {
@@ -543,7 +544,7 @@ export class OrderService {
     let lastError: unknown
     for (let attempt = 1; attempt <= ORDER_SUBMIT_MAX_RETRY; attempt += 1) {
       try {
-        return await AppDataSource.transaction(async (manager) => {
+        return await runInTransaction(async (manager) => {
           const orderRepo = manager.getRepository(BizOutboundOrder)
           const itemRepo = manager.getRepository(BizOutboundOrderItem)
           const productRepo = manager.getRepository(BaseProduct)

--- a/backend/src/services/persistent-risk-state.service.ts
+++ b/backend/src/services/persistent-risk-state.service.ts
@@ -16,6 +16,7 @@ import { createHash } from 'node:crypto'
 import { LessThanOrEqual, type EntityManager } from 'typeorm'
 import type { ClientRateLimitInfo, Options, Store } from 'express-rate-limit'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { AuthRiskState } from '../entities/auth-risk-state.entity.js'
 import { isRetryableTransactionLockError } from '../utils/database-errors.js'
 import { databaseMaintenanceModeService } from './database-maintenance-mode.service.js'
@@ -157,7 +158,7 @@ class PersistentRiskStateService {
     maxRequests?: number,
   ): Promise<ClientRateLimitInfo> {
     return this.runWithLockRetry(() =>
-      AppDataSource.transaction(async (manager) => {
+      runInTransaction(async (manager) => {
         const state = await this.loadLockedState(
           manager,
           digestBucketKey(`rate_limit:${bucketKey}`),
@@ -206,7 +207,7 @@ class PersistentRiskStateService {
   async decrementWindow(bucketKey: string, windowMs: number, nowMs = Date.now()): Promise<void> {
     const bucketDigest = digestBucketKey(`rate_limit:${bucketKey}`)
     await this.runWithLockRetry(() =>
-      AppDataSource.transaction(async (manager) => {
+      runInTransaction(async (manager) => {
         const repository = manager.getRepository(AuthRiskState)
         const query = repository.createQueryBuilder('state').where('state.bucketDigest = :bucketDigest', { bucketDigest })
         if (AppDataSource.options.type === 'mysql') query.setLock('pessimistic_write')
@@ -257,7 +258,7 @@ class PersistentRiskStateService {
   ): Promise<PersistentFailureState> {
     const now = new Date(nowMs)
     return this.runWithLockRetry(() =>
-      AppDataSource.transaction(async (manager) => {
+      runInTransaction(async (manager) => {
         const state = await this.loadLockedState(
           manager,
           digestBucketKey(`login_failure:${bucketKey}`),

--- a/backend/src/services/product.service.ts
+++ b/backend/src/services/product.service.ts
@@ -8,6 +8,7 @@
 
 import { In, type EntityManager, type Repository } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { BaseProduct } from '../entities/base-product.entity.js'
 import { BaseProductSku } from '../entities/base-product-sku.entity.js'
 import { RelProductTag } from '../entities/rel-product-tag.entity.js'
@@ -363,7 +364,7 @@ export class ProductService {
   }
 
   async create(input: CreateProductInput): Promise<ProductView> {
-    return AppDataSource.transaction((manager) => this.createWithManager(input, manager))
+    return runInTransaction((manager) => this.createWithManager(input, manager))
   }
 
   async batchCreate(inputs: CreateProductInput[]): Promise<ProductView[]> {
@@ -376,7 +377,7 @@ export class ProductService {
 
     this.assertNoDuplicateProductCodesInBatch(inputs)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const createdProducts: ProductView[] = []
 
       for (let index = 0; index < inputs.length; index += 1) {
@@ -397,7 +398,7 @@ export class ProductService {
   }
 
   async update(id: string, input: UpdateProductInput): Promise<ProductView> {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(BaseProduct)
       const product = await repo.findOne({
         where: { id },
@@ -431,7 +432,7 @@ export class ProductService {
       throw new BizError('至少提供一个可更新字段')
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const repo = manager.getRepository(BaseProduct)
       const products = await repo.find({
         where: { id: In(productIds) },
@@ -452,7 +453,7 @@ export class ProductService {
   }
 
   async delete(id: string): Promise<void> {
-    await AppDataSource.transaction(async (manager) => {
+    await runInTransaction(async (manager) => {
       const productRepo = manager.getRepository(BaseProduct)
       const product = await productRepo.findOne({
         where: { id },

--- a/backend/src/services/system-config.service.ts
+++ b/backend/src/services/system-config.service.ts
@@ -7,6 +7,7 @@
  */
 
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { BizOutboundOrder } from '../entities/biz-outbound-order.entity.js'
 import { O2oPreorder } from '../entities/o2o-preorder.entity.js'
 import { SystemConfig } from '../entities/system-config.entity.js'
@@ -1374,7 +1375,7 @@ class SystemConfigService {
     this.validateInputValue('walkin', input.walkin)
     await this.ensureDefaultConfigs()
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const keys = this.getOrderSerialAllKeys()
       const placeholders = keys.map(() => '?').join(', ')
       const useForUpdate = manager.connection.options.type === 'mysql'
@@ -1582,7 +1583,7 @@ class SystemConfigService {
     }
 
     await this.ensureDefaultConfigs()
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const useForUpdate = manager.connection.options.type === 'mysql'
       const placeholders = this.o2oConfigKeys.map(() => '?').join(', ')
       const lockedRows: Array<{ id: string; configKey: string; configValue: string; updatedAt: string }> = await manager.query(
@@ -1798,7 +1799,7 @@ class SystemConfigService {
     }
 
     await this.ensureDefaultConfigs()
-    const result = await AppDataSource.transaction(async (manager) => {
+    const result = await runInTransaction(async (manager) => {
       const useForUpdate = manager.connection.options.type === 'mysql'
       const placeholders = this.customerServiceConfigKeys.map(() => '?').join(', ')
       const lockedRows: Array<{ id: string; configKey: string; configValue: string; updatedAt: string }> = await manager.query(
@@ -1930,7 +1931,7 @@ class SystemConfigService {
       : this.buildTreeFromOptions(input.options ?? [])
     const normalizedOptions = this.buildClientDepartmentOptionsFromTree(normalizedTree)
     await this.ensureDefaultConfigs()
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const useForUpdate = manager.connection.options.type === 'mysql'
       const lockedRows: Array<{ id: string; configKey: string; configValue: string; updatedAt: string }> = await manager.query(
         `
@@ -2104,7 +2105,7 @@ class SystemConfigService {
       }
     }
 
-    return manager ? execute(manager) : AppDataSource.transaction(execute)
+    return manager ? execute(manager) : runInTransaction(execute)
   }
 
   async assertClientDepartmentOption(departmentName?: string) {
@@ -2134,7 +2135,7 @@ class SystemConfigService {
     const normalizedMobile = this.normalizeVerificationProviderInput('mobile', input.mobile, persistedConfigs.mobile)
     const normalizedEmail = this.normalizeVerificationProviderInput('email', input.email, persistedConfigs.email)
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const useForUpdate = manager.connection.options.type === 'mysql'
       const placeholders = this.verificationConfigKeys.map(() => '?').join(', ')
       const lockedRows: Array<{ id: string; configKey: string; configValue: string; updatedAt: string }> = await manager.query(

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -7,6 +7,7 @@
  */
 
 import { AppDataSource } from '../config/data-source.js'
+import { runInTransaction } from '../config/transaction-runner.js'
 import { SysUser } from '../entities/sys-user.entity.js'
 import { SysUserSession } from '../entities/sys-user-session.entity.js'
 import type { AuthUserContext, UserRole, UserSafeProfile, UserStatus } from '../types/auth.js'
@@ -126,7 +127,7 @@ export class UserService {
       throw new BizError('姓名不能为空', 400)
     }
     try {
-      return await AppDataSource.transaction(async (manager) => {
+      return await runInTransaction(async (manager) => {
         const userRepo = manager.getRepository(SysUser)
         const passwordHash = await hashPassword(password)
         const entity = userRepo.create({
@@ -188,7 +189,7 @@ export class UserService {
       throw new BizError('姓名不能为空', 400)
     }
     try {
-      return await AppDataSource.transaction(async (manager) => {
+      return await runInTransaction(async (manager) => {
         const userRepo = manager.getRepository(SysUser)
         const sessionRepo = manager.getRepository(SysUserSession)
         const user = await userRepo.findOne({ where: { id } })
@@ -263,7 +264,7 @@ export class UserService {
     actor: AuthUserContext,
     requestMeta?: RequestMeta,
   ): Promise<UserSafeProfile> {
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(SysUser)
       const user = await userRepo.findOne({ where: { id } })
       if (!user) {
@@ -328,7 +329,7 @@ export class UserService {
       throw new BizError('请使用本人修改密码入口处理自己的密码', 400)
     }
 
-    return AppDataSource.transaction(async (manager) => {
+    return runInTransaction(async (manager) => {
       const userRepo = manager.getRepository(SysUser)
       const sessionRepo = manager.getRepository(SysUserSession)
       const user = await userRepo.findOne({ where: { id } })


### PR DESCRIPTION
Closes #36

## Summary

`DB_TYPE` 默认为 `sqlite`（一体化部署的默认形态），此时两个请求的写事务在时间上重叠会直接失败，用户表现为多人同时提单时一部分请求返回 500。

**根因**：TypeORM 的 sqlite 驱动只持有**一条**连接，`AppDataSource.transaction()` 的 `BEGIN`/`COMMIT` 也走这条连接。Node 的异步调度让两个事务的语句交错：

- 后进入的 `BEGIN TRANSACTION` 撞上尚未提交的事务 → `SQLITE_ERROR: cannot start a transaction within a transaction`
- 绕过后 TypeORM 检测到活跃事务改用 SAVEPOINT，交错又让 savepoint 栈的进出顺序错乱 → `no such savepoint: typeorm_N`

MySQL 走连接池、每个事务独占连接，本就没有这个问题。

**重试治不了**：`order.service.ts` 已有 `ORDER_SUBMIT_MAX_RETRY = 3` 的有界重试，但只认 `SQLITE_BUSY`/`SQLITE_LOCKED`。实测把上述两个错误纳入重试并加退避抖动后，错误只是从前者变成后者——一旦交错发生，savepoint 栈本身已经乱了。唯一可靠的解法是让写事务排队。

## 改动

**新增 `backend/src/config/transaction-runner.ts`**：统一写事务入口 `runInTransaction(fn)`

- **MySQL 直接透传**，不引入任何额外排队开销
- **SQLite 用 promise 链串行化**，同一时刻只跑一个写事务
- **带重入放行**：用 `AsyncLocalStorage` 记录事务深度，事务体内再次进入时直接执行而不排队，避免"外层持锁、内层排队"自死锁
- 队列的 `then` 两个分支接同一函数、并吞掉结果与异常，避免一次事务失败毒化后续所有事务

**15 个 service 共 78 处调用点收口**到新入口。

### 关于重入放行的前置验证

朴素互斥量的最大风险是事务嵌套自死锁。用 `AsyncLocalStorage` 深度计数探针跑了 7 个 verify 套件（`release-full-regression` / `o2o-preorder` / `inventory-invariants` / `feedback-customer-service` / `client-auth-department-governance` / `permission-regression` / `o2o-sku-selection`），**嵌套检出均为 0**——现有代码普遍遵循"事务内调用下游方法时透传 `manager`"的约定。

探针本身经过自测有效（单独构造一次嵌套调用，如期打印 `[NESTED-TX depth=2]`），不是哑弹。

动态覆盖不等于证明，所以重入放行仍然保留，作为未来新代码的兜底：最坏退化回今天的行为，而不是把请求挂死。探针代码是临时的，未进入提交。

**顺带修正 `task8-verify.ts` 的看板下钻断言**：看板的"客户"维度取的是申请部门（`COALESCE(NULLIF(TRIM(customer_department_name), ''), '散客')`，`dashboard.service.ts` 三处一致），散客单统一归到 `散客` 这一个桶，不是按订单 `customerName` 逐个成桶——原先按 `散客1` 查不到任何记录。该脚本的并发用例现作为本修复的回归守卫。

## Test plan

- [x] `cd backend && npm run check`（tsc --noEmit）
- [x] `backend/scripts/task8-verify.ts` **全绿**，含此前一直失败的 `并发单号生成`（并发提交 16 笔出库单，8 笔散客 + 8 笔部门，校验同类无重复、双类型不串号、流水连续）
- [x] `backend/scripts/release-full-regression-verify.ts`
- [x] `backend/scripts/inventory-invariants-verify.ts`
- [x] `backend/scripts/o2o-preorder-verify.ts`
- [x] `backend/scripts/security-hardening-verify.ts`、`security-findings-remediation-verify.ts`
- [x] `backend/scripts/permission-regression-verify.ts`
- [ ] `npm run verify:db:concurrency`（MySQL 8.4 路径，确认串行化入口对 MySQL 是纯透传、行为无变化）—— 待 CI 执行

## 维护约定

新增写事务**一律用 `runInTransaction`，不要直接调用 `AppDataSource.transaction`**，否则该事务会绕过闸门、重新引入并发失败。已在 `transaction-runner.ts` 文件头写明。后续可考虑加一条 lint 规则做机器强制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCP2rgfetwi2NFEzTjEQoi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCP2rgfetwi2NFEzTjEQoi)_