### PR TITLE
ci: 把 task8:verify 接入流水线与聚合套件

### DIFF
--- a/.github/workflows/verify-db-concurrency.yml
+++ b/.github/workflows/verify-db-concurrency.yml
@@ -8,8 +8,10 @@
 # 1. 在手动触发、主分支推送或拉取请求时执行；
 # 2. 安装根目录与后端依赖前，显式把 npm registry 固定为官方源；
 # 3. 安装完成后分别执行根目录与后端 `npm audit`，确保 CI 使用官方审计口径；
-# 4. 最后复用统一命令 `npm run verify:db:concurrency`；
-# 5. MySQL 临时环境由脚本内部自动通过 Docker Compose 准备与清理，避免 CI 额外维护服务编排。
+# 4. 先跑 `task8:verify` 守住 SQLite 并发写事务（只依赖本地 SQLite，秒级完成，失败即止，
+#    不必先花时间拉起 Docker MySQL）；
+# 5. 最后复用统一命令 `npm run verify:db:concurrency` 覆盖 MySQL 侧；
+# 6. MySQL 临时环境由脚本内部自动通过 Docker Compose 准备与清理，避免 CI 额外维护服务编排。
 #
 name: verify-db-concurrency
 
@@ -58,6 +60,13 @@ jobs:
 
       - name: 执行后端依赖安全审计
         run: npm --prefix ./backend audit --audit-level=high
+
+      # SQLite 侧的并发写事务回归：并发提交 16 笔出库单，若哪天写事务绕过
+      # `runInTransaction` 闸门、直接调用 `AppDataSource.transaction`，这一步会立刻报
+      # `cannot start a transaction within a transaction` 或 `no such savepoint`。
+      # 该守卫此前不在任何流水线里，正因如此 issue #36 才长期未被发现。
+      - name: 执行 SQLite 并发写事务回归
+        run: npm --prefix ./backend run task8:verify
 
       - name: 执行数据库并发验收
         run: npm run verify:db:concurrency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,9 +1369,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/scripts/verify-unit-functional-suite.mjs
+++ b/scripts/verify-unit-functional-suite.mjs
@@ -80,6 +80,12 @@ const main = async () => {
   // - 防止系统配置页新增白名单治理后，后续改动把目录接口或权限链路悄悄带坏。
   await runNpmScript('后端教职工目录治理回归', 'client-staff-directory:verify', backendRoot)
 
+  // 双流水单号与 SQLite 并发写事务回归：
+  // - 并发提交 16 笔出库单，守住 issue #36 修复的写事务串行化——若写事务绕过
+  //   `runInTransaction` 闸门直接调用 `AppDataSource.transaction`，这一步会立刻失败；
+  // - 同时覆盖 Task8 迁移脚本、凭证打印链路与看板下钻的静态与运行态契约。
+  await runNpmScript('后端双流水单号与并发写事务回归', 'task8:verify', backendRoot)
+
   log('\n[unit-functional] 单元功能测试套件执行完成')
 }
 


### PR DESCRIPTION
## Summary

`task8:verify` 此前**不在任何 CI workflow、也不在 `verify:all` 聚合套件里**。正因如此它自身的三处失效断言长期无人发现，进而让它守护的「SQLite 并发写事务」缺陷（#36）一直没有暴露——脚本在第一条断言就挂了，根本跑不到并发那一步。

#38 修好 #36 之后，这个脚本的并发用例成了写事务串行化的回归守卫。守卫只有真正跑起来才有意义，所以把它接进去：

- **`.github/workflows/verify-db-concurrency.yml`** 增加「执行 SQLite 并发写事务回归」步骤，放在 MySQL 并发验收**之前**——它只依赖本地 SQLite、秒级完成，SQLite 侧一旦回归就能在拉起 Docker MySQL 之前失败退出
- **`scripts/verify-unit-functional-suite.mjs`** 增加对应步骤，使 `npm run verify:all` 本地也覆盖

选这条 workflow 而不是新建一个，是因为它本就是数据库并发主题，依赖安装步骤可直接复用。

## 守卫有效性验证

新加的门禁如果是哑弹就毫无价值，所以做了反向验证：把 `order.service.ts` 中**一处**调用点改回直接调用 `AppDataSource.transaction`（其余 77 处不动），`task8:verify` 立刻复现原始报错——

```
✅ Task8 迁移与历史映射脚本已补齐且包含关键语句
✅ 凭证预览与打印链路关键实现存在
✅ 运行态结构校验通过：字段与关键索引均已生效
Task8 自动化验证失败： QueryFailedError: SQLITE_ERROR: cannot start a transaction within a transaction
```

恢复后重新全绿。也就是说，将来任何一处写事务绕过 `runInTransaction` 闸门，CI 都会拦住。

## Test plan

- [x] `node scripts/verify-unit-functional-suite.mjs` 全流程通过（含新增步骤）
- [x] `cd backend && npx tsx scripts/task8-verify.ts` 全绿
- [x] `cd backend && npm run check`
- [x] workflow YAML 解析校验，步骤顺序符合预期
- [x] 反向验证：单点绕过闸门 → 守卫如期失败；恢复 → 重新通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCP2rgfetwi2NFEzTjEQoi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCP2rgfetwi2NFEzTjEQoi)_