### PR TITLE
fix: 收口 SQLite 事务协调器的 QueryRunner 与原始 SQL 入口

### DIFF
--- a/.github/workflows/verify-db-concurrency.yml
+++ b/.github/workflows/verify-db-concurrency.yml
@@ -10,10 +10,11 @@
 # 3. 安装完成后分别执行根目录与后端 `npm audit`，确保 CI 使用官方审计口径；
 # 4. 先做写事务闸门静态契约检查——纯静态、无任何运行时依赖，最快暴露绕过闸门的新代码；
 # 5. 再跑 MySQL 启动结构契约，确保漏执行 035/036 时会在对外服务前阻断；
-# 6. 接着跑 `task8:verify` 守住 SQLite 并发写事务（只依赖本地 SQLite，秒级完成，失败即止，
+# 6. 接着跑 `transaction-coordinator:verify`，覆盖 QueryRunner 长事务租约、异常 release 与原始事务 SQL 门禁；
+# 7. 再跑 `task8:verify` 守住 SQLite 业务并发写事务（两者只依赖本地 SQLite，失败即止，
 #    不必先花时间拉起 Docker MySQL）；
-# 7. 最后复用统一命令 `npm run verify:db:concurrency` 覆盖 MySQL 侧；
-# 8. MySQL 临时环境由脚本内部自动通过 Docker Compose 准备与清理，避免 CI 额外维护服务编排。
+# 8. 最后复用统一命令 `npm run verify:db:concurrency` 覆盖 MySQL 侧；
+# 9. MySQL 临时环境由脚本内部自动通过 Docker Compose 准备与清理，避免 CI 额外维护服务编排。
 #
 name: verify-db-concurrency
 
@@ -70,6 +71,9 @@ jobs:
 
       - name: 执行 MySQL 启动结构契约验收
         run: npm --prefix ./backend run verify:mysql:schema-contract
+
+      - name: 执行 SQLite 事务协调器入口覆盖回归
+        run: npm --prefix ./backend run transaction-coordinator:verify
 
       # SQLite 侧的并发写事务回归：并发提交 16 笔出库单，若哪天写事务绕过
       # `runInTransaction` 闸门、直接调用 `AppDataSource.transaction`，这一步会立刻报

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "audit:prod:mysql": "node scripts/audit-mysql-production.mjs",
     "verify:db:concurrency": "node ../scripts/run-verify-db-concurrency.mjs",
     "verify:db:concurrency:raw": "tsx scripts/verify-db-concurrency.ts",
+    "transaction-coordinator:verify": "node --import tsx scripts/transaction-coordinator-verify.ts",
     "verify:mysql:schema-contract": "node --import tsx scripts/mysql-schema-contract-verify.ts",
     "verify:db:migration:foundation": "tsx scripts/database-migration-foundation-verify.ts",
     "verify:app-data-paths:env-file": "tsx scripts/app-data-paths-env-file-verify.ts",

--- a/backend/scripts/transaction-coordinator-verify.ts
+++ b/backend/scripts/transaction-coordinator-verify.ts
@@ -1,0 +1,259 @@
+/**
+ * 文件说明：backend/scripts/transaction-coordinator-verify.ts
+ * 文件职责：验证 SQLite 事务协调器对 DataSource 与 QueryRunner 入口的完整串行化边界。
+ * 实现逻辑：
+ * - 用独立内存 SQLite 数据源构造 QueryRunner 长事务，确认事务外查询必须等待提交或回滚；
+ * - 并发启动两个 QueryRunner 事务，确认第二个事务在第一个释放租约前不能进入；
+ * - 校验 release 会回滚未完成事务并释放租约，避免异常路径永久堵塞写队列；
+ * - 拒绝通过 DataSource.query / QueryRunner.query 直接下发事务控制 SQL，消除无法识别所有者的跨语句事务。
+ * 维护说明：本脚本不连接业务库，也不读取 DB_*；所有数据仅存在于当前进程的内存 SQLite 中。
+ */
+
+import 'reflect-metadata'
+import assert from 'node:assert/strict'
+import { DataSource, type QueryRunner } from 'typeorm'
+import {
+  installTransactionCoordinator,
+  type TransactionCoordinator,
+} from '../src/database/transaction-coordinator.js'
+
+const WAIT_PROBE_MS = 40
+
+const pass = (message: string) => {
+  console.log(`✅ ${message}`)
+}
+
+const delay = (durationMs: number) => new Promise<void>((resolve) => {
+  setTimeout(resolve, durationMs)
+})
+
+const createVerifyDataSource = async (): Promise<{
+  dataSource: DataSource
+  coordinator: TransactionCoordinator
+}> => {
+  const dataSource = new DataSource({
+    type: 'sqlite',
+    database: ':memory:',
+    entities: [],
+    synchronize: false,
+    logging: false,
+  })
+  await dataSource.initialize()
+  const coordinator = installTransactionCoordinator(dataSource, {
+    serializeWrites: true,
+    maxPendingWrites: 8,
+    writeQueueTimeoutMs: 1_000,
+  })
+  await dataSource.query(`
+    CREATE TABLE transaction_coordinator_probe (
+      id INTEGER PRIMARY KEY,
+      label TEXT NOT NULL
+    )
+  `)
+  return { dataSource, coordinator }
+}
+
+const rollbackIfActive = async (queryRunner: QueryRunner): Promise<void> => {
+  if (!queryRunner.isTransactionActive) {
+    return
+  }
+  await queryRunner.rollbackTransaction().catch(() => undefined)
+}
+
+const verifyQueryRunnerBlocksOutsideQueries = async (
+  dataSource: DataSource,
+  coordinator: TransactionCoordinator,
+): Promise<void> => {
+  const queryRunner = dataSource.createQueryRunner()
+  let outsideQuerySettled = false
+  let outsideQuery: Promise<number> | undefined
+
+  try {
+    await queryRunner.startTransaction()
+    await queryRunner.query(
+      'INSERT INTO transaction_coordinator_probe (id, label) VALUES (?, ?)',
+      [1, '待回滚'],
+    )
+
+    outsideQuery = dataSource
+      .query('SELECT COUNT(*) AS count FROM transaction_coordinator_probe')
+      .then((rows: Array<{ count: number | string }>) => {
+        outsideQuerySettled = true
+        return Number(rows[0]?.count ?? -1)
+      })
+
+    await delay(WAIT_PROBE_MS)
+    assert.equal(outsideQuerySettled, false, 'QueryRunner 活动事务外的查询必须等待写租约释放')
+    assert.ok(coordinator.snapshot().pendingWrites >= 1, '事务外查询应进入同一有界队列')
+
+    await queryRunner.rollbackTransaction()
+    assert.equal(await outsideQuery, 0, 'QueryRunner 回滚后，事务外查询不得观察到未提交数据')
+  } finally {
+    await rollbackIfActive(queryRunner)
+    await queryRunner.release().catch(() => undefined)
+    await outsideQuery?.catch(() => undefined)
+  }
+
+  pass('QueryRunner 长事务会阻塞事务外查询，回滚后不泄露未提交数据')
+}
+
+const verifyConcurrentQueryRunnerTransactions = async (
+  dataSource: DataSource,
+  coordinator: TransactionCoordinator,
+): Promise<void> => {
+  const firstRunner = dataSource.createQueryRunner()
+  const secondRunner = dataSource.createQueryRunner()
+  let secondTransactionStarted = false
+  let secondStart: Promise<void> | undefined
+
+  try {
+    assert.notEqual(firstRunner, secondRunner, '每次 createQueryRunner 必须返回独立的逻辑事务所有者')
+    await firstRunner.startTransaction()
+    secondStart = secondRunner.startTransaction().then(() => {
+      secondTransactionStarted = true
+    })
+
+    await delay(WAIT_PROBE_MS)
+    assert.equal(secondTransactionStarted, false, '第二个 QueryRunner 事务必须等待首个事务结束')
+    assert.ok(coordinator.snapshot().pendingWrites >= 1, '第二个 QueryRunner 事务应进入写队列')
+
+    await firstRunner.commitTransaction()
+    await secondStart
+    assert.equal(secondRunner.isTransactionActive, true, '首个事务提交后，第二个事务应正常启动')
+    await secondRunner.rollbackTransaction()
+  } finally {
+    await rollbackIfActive(firstRunner)
+    await secondStart?.catch(() => undefined)
+    await rollbackIfActive(secondRunner)
+    await firstRunner.release().catch(() => undefined)
+    await secondRunner.release().catch(() => undefined)
+  }
+
+  pass('多个 QueryRunner 事务共用同一有界写队列并按租约顺序执行')
+}
+
+const verifyQueryRunnerManagerAndNestedTransaction = async (
+  dataSource: DataSource,
+): Promise<void> => {
+  const queryRunner = dataSource.createQueryRunner()
+  let outsideQuerySettled = false
+  let outsideQuery: Promise<number> | undefined
+
+  try {
+    await queryRunner.startTransaction()
+    await queryRunner.startTransaction()
+    await queryRunner.manager.query(
+      'INSERT INTO transaction_coordinator_probe (id, label) VALUES (?, ?)',
+      [3, 'manager 与 QueryBuilder'],
+    )
+
+    const insideRow = await queryRunner.manager
+      .createQueryBuilder()
+      .select('COUNT(*)', 'count')
+      .from('transaction_coordinator_probe', 'probe')
+      .where('probe.id = :id', { id: 3 })
+      .clone()
+      .getRawOne<{ count: number | string }>()
+    assert.equal(Number(insideRow?.count ?? -1), 1, 'QueryRunner manager 的 QueryBuilder 应复用当前事务租约')
+
+    outsideQuery = dataSource
+      .query('SELECT COUNT(*) AS count FROM transaction_coordinator_probe WHERE id = ?', [3])
+      .then((rows: Array<{ count: number | string }>) => {
+        outsideQuerySettled = true
+        return Number(rows[0]?.count ?? -1)
+      })
+
+    await queryRunner.commitTransaction()
+    await delay(WAIT_PROBE_MS)
+    assert.equal(outsideQuerySettled, false, '提交内层 savepoint 后仍应由外层事务持有租约')
+
+    await queryRunner.commitTransaction()
+    assert.equal(await outsideQuery, 1, '提交最外层事务后，事务外查询应看到已提交数据')
+  } finally {
+    await rollbackIfActive(queryRunner)
+    await queryRunner.release().catch(() => undefined)
+    await outsideQuery?.catch(() => undefined)
+  }
+
+  pass('QueryRunner manager/QueryBuilder 与嵌套事务均复用同一长事务租约')
+}
+
+const verifyReleaseRollsBackAndReleasesLease = async (
+  dataSource: DataSource,
+  coordinator: TransactionCoordinator,
+): Promise<void> => {
+  const queryRunner = dataSource.createQueryRunner()
+  await queryRunner.startTransaction()
+  await queryRunner.query(
+    'INSERT INTO transaction_coordinator_probe (id, label) VALUES (?, ?)',
+    [2, 'release 清理'],
+  )
+
+  await queryRunner.release()
+  await coordinator.waitForIdle()
+
+  const rows = await dataSource.query(
+    'SELECT COUNT(*) AS count FROM transaction_coordinator_probe WHERE id = ?',
+    [2],
+  ) as Array<{ count: number | string }>
+  assert.equal(Number(rows[0]?.count ?? -1), 0, 'release 必须回滚未完成的 QueryRunner 事务')
+  assert.equal(coordinator.snapshot().activeWrites, 0, 'release 后不得残留活动写租约')
+
+  pass('QueryRunner.release 会回滚未完成事务并释放写租约')
+}
+
+const verifyRawTransactionSqlIsRejected = async (dataSource: DataSource): Promise<void> => {
+  let dataSourceTransactionStarted = false
+  try {
+    await assert.rejects(
+      async () => {
+        await dataSource.query('/* issue #41 */ ; BEGIN IMMEDIATE')
+        dataSourceTransactionStarted = true
+      },
+      /禁止通过 DataSource\.query 直接控制事务边界/,
+    )
+  } finally {
+    if (dataSourceTransactionStarted) {
+      await dataSource.query('ROLLBACK').catch(() => undefined)
+    }
+  }
+
+  const queryRunner = dataSource.createQueryRunner()
+  let queryRunnerTransactionStarted = false
+  try {
+    await assert.rejects(
+      async () => {
+        await queryRunner.query('-- issue #41\nSAVEPOINT manual_transaction')
+        queryRunnerTransactionStarted = true
+      },
+      /禁止通过 QueryRunner\.query 直接控制事务边界/,
+    )
+  } finally {
+    if (queryRunnerTransactionStarted) {
+      await queryRunner.query('ROLLBACK').catch(() => undefined)
+    }
+    await queryRunner.release().catch(() => undefined)
+  }
+
+  pass('DataSource.query 与 QueryRunner.query 的原始事务控制 SQL 已被运行时拒绝')
+}
+
+const main = async () => {
+  const { dataSource, coordinator } = await createVerifyDataSource()
+  try {
+    await verifyQueryRunnerBlocksOutsideQueries(dataSource, coordinator)
+    await verifyConcurrentQueryRunnerTransactions(dataSource, coordinator)
+    await verifyQueryRunnerManagerAndNestedTransaction(dataSource)
+    await verifyReleaseRollsBackAndReleasesLease(dataSource, coordinator)
+    await verifyRawTransactionSqlIsRejected(dataSource)
+  } finally {
+    await dataSource.destroy()
+  }
+
+  console.log('事务协调器 QueryRunner 覆盖回归通过')
+}
+
+main().catch((error) => {
+  console.error('事务协调器 QueryRunner 覆盖回归失败：', error)
+  process.exitCode = 1
+})

--- a/backend/scripts/write-transaction-contract-verify.ts
+++ b/backend/scripts/write-transaction-contract-verify.ts
@@ -18,17 +18,16 @@
  *    既避免代码删改后条目退化成死条目，也避免一条豁免顺带放行同文件（乃至同函数）内新增的其它调用；
  * 5. 顺带确认 runInTransaction 确实被服务层广泛使用，防止闸门被整体架空后本门禁仍然“通过”。
  *
- * 门禁挡住的到底是什么（#35 引入事务协调器之后）：
+ * 门禁挡住的到底是什么（#41 收口事务协调器入口之后）：
  * `transaction-coordinator.ts` 会 patch `dataSource.transaction` / `query` / queryBuilder /
- * 全局 EntityManager，因此直接调用 `AppDataSource.transaction` 在协调器装好之后确实也会被串行化。
- * 但仍有两个缺口需要本门禁把守：
- * 1. **`queryRunner.startTransaction()` 完全不在 patch 覆盖范围内**（协调器没有 patch
- *    `createQueryRunner`），走这条路的写事务至今仍会绕过串行化；
- * 2. **`query('BEGIN')` 这类原始事务控制 SQL 同样不受保护**——`patchDataSourceQuery` 只按单条语句
- *    获取租约，`BEGIN` 返回后租约即释放，后续事务语句仍可与其它写入交错；
- * 3. `runInTransaction` 会先 `initializeDatabaseInfrastructure` 再开事务，直接调用则不保证这个次序——
+ * 全局 EntityManager 与 `createQueryRunner`：QueryRunner 生命周期会跨语句持有租约，原始事务控制 SQL
+ * 则由运行时明确拒绝。因此本门禁现在承担“更早失败 + 保证初始化次序 + 约束业务入口”的职责：
+ * 1. `runInTransaction` 会先 `initializeDatabaseInfrastructure` 再开事务，直接调用不保证这个次序——
  *    协调器尚未装好时开的事务不受任何保护。
- * 换言之：约定「一律走 runInTransaction」不是风格偏好，而是这两处保证的唯一来源。
+ * 2. 原始事务 SQL 虽会在协调器安装后被运行时拒绝，但静态门禁可在 CI 中指出具体源码位置，
+ *    避免把错误推迟到对应分支首次运行。
+ * 3. 业务层仍应统一走 `runInTransaction`；QueryRunner 仅供确需固定连接或手动批次边界的基础设施代码使用，
+ *    且必须显式登记豁免原因。
  *
  * 为什么用 AST 而不是正则：
  * 初版按行正则匹配 `identifier.transaction(`，有两个可被绕过的口子——
@@ -44,8 +43,8 @@
  * 已知边界（不要把本门禁当成完备证明）：
  * 事务控制 SQL 的识别依赖静态求值，唯一判不了的是「整条 SQL 以无法静态解析的值开头」——
  * 例如 `` `${verb} TRANSACTION` ``，或 SQL 由函数参数、配置、数据库内容传入。
- * 这是静态分析的固有边界，靠加规则堵不住；真正收口需要在协调器侧接管
- * `createQueryRunner` 与跨语句租约（见 issue #41）。
+ * 这是静态分析的固有边界，靠加规则堵不住；协调器已在运行时拒绝动态原始事务 SQL，并接管
+ * `createQueryRunner` 的跨语句租约（见 issue #41）。静态门禁仍负责未初始化数据源与代码规范的前置保护。
  *
  * 维护说明：
  * - 新增写事务请一律调用 `runInTransaction`（backend/src/config/transaction-runner.ts）；
@@ -64,11 +63,10 @@ const TRANSACTION_ENTRY_METHODS = new Set(['transaction', 'startTransaction'])
 
 /**
  * 事务控制 SQL：直接 `query('BEGIN')` 同样能开启事务，且完全不经过上面那两个方法。
- * 这条路比方法调用更危险——协调器的 `patchDataSourceQuery` 只按**单条语句**获取租约，
- * `BEGIN` 返回后租约即释放，后续事务语句仍可与其它写入交错，等于没有任何串行化保护。
+ * 协调器安装后会在运行时拒绝这条路；静态门禁继续负责在 CI 中提前给出源码位置。
  */
 const TRANSACTION_CONTROL_SQL_PATTERN =
-  /^(BEGIN|START\s+TRANSACTION|COMMIT|ROLLBACK|SAVEPOINT|RELEASE\s+SAVEPOINT|SET\s+TRANSACTION)\b/i
+  /^(BEGIN|START\s+TRANSACTION|COMMIT|END(?:\s+TRANSACTION)?|ROLLBACK|SAVEPOINT|RELEASE(?:\s+SAVEPOINT)?|SET\s+TRANSACTION)\b/i
 
 /**
  * 去掉 SQL 的前导空白与注释后再判定关键字。
@@ -94,6 +92,10 @@ const stripLeadingSqlNoise = (sql: string): string => {
         return ''
       }
       rest = trimmed.slice(end + 1)
+      continue
+    }
+    if (trimmed.startsWith(';')) {
+      rest = trimmed.slice(1)
       continue
     }
     return trimmed
@@ -263,6 +265,18 @@ const ALLOWED_DIRECT_TRANSACTION_CALLS: Array<{
     reason:
       '协调器安装点本身：它正是把 dataSource.transaction 接管为串行化实现的地方，'
       + '必须直接触碰原方法（先 bind 保留原实现，再覆写），无法经由 runInTransaction',
+  },
+  {
+    relativePath: 'src/database/transaction-coordinator.ts',
+    receiver: 'queryRunner',
+    method: 'startTransaction',
+    enclosingFunction: 'wrapQueryRunner',
+    // 两处：绑定原生命周期方法留作安全转发，以及把持有长事务租约的包装实现写回门面。
+    expectedCount: 2,
+    reason:
+      '协调器的 QueryRunner 接管实现：先保留 TypeORM 原始 startTransaction，'
+      + '再用跨 start/commit/rollback/release 生命周期持有租约的包装方法替换；'
+      + '这是保护 QueryRunner 入口本身，不能反向调用业务层 runInTransaction',
   },
   {
     relativePath: 'src/config/database-bootstrap.ts',

--- a/backend/src/database/transaction-coordinator.ts
+++ b/backend/src/database/transaction-coordinator.ts
@@ -3,14 +3,15 @@
  * 文件职责：提供数据库无关的事务上下文复用，以及 SQLite 单写者的有界串行协调。
  * 实现逻辑：
  * - AsyncLocalStorage 记录当前事务 manager，嵌套 `DataSource.transaction` 复用同一 manager；
- * - SQLite 的显式事务、Repository/QueryBuilder/SQL 读写共用一把有界连接锁；
+ * - SQLite 的显式事务、QueryRunner、Repository/QueryBuilder/SQL 读写共用一把有界连接锁；
+ * - QueryRunner 在 start/commit/rollback/release 生命周期内持有同一租约，原始事务控制 SQL 被运行时拒绝；
  * - 队列满或等待超时返回可重试的 503，防止高峰期形成无界 Promise/内存堆积。
  * 维护说明：业务层仍应优先显式透传 manager；这里的自动委派是兼容旧调用的安全兜底，不替代清晰的事务边界。
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { performance } from 'node:perf_hooks'
-import type { DataSource, EntityManager } from 'typeorm'
+import type { DataSource, EntityManager, QueryRunner } from 'typeorm'
 import { DatabaseOverloadedError } from './database-errors.js'
 
 type TransactionHandler = (manager: EntityManager) => Promise<unknown>
@@ -21,6 +22,13 @@ interface TransactionExecutionContext {
   dataSource: DataSource
   manager?: EntityManager
   ownsWriteLease: boolean
+  writeLeaseToken?: symbol
+}
+
+interface QueryRunnerLeaseState {
+  release?: ReleaseLease
+  borrowedLeaseToken?: symbol
+  allowedTransactionControlDepth: number
 }
 
 interface QueueEntry {
@@ -126,6 +134,19 @@ const SYNCHRONOUS_MANAGER_FACTORY_METHODS = new Set([
   'createQueryBuilder',
 ])
 
+/**
+ * 原始事务控制 SQL 无法在 DataSource.query 的多次调用之间可靠识别所有者：
+ * BEGIN 返回后，调用方的 await 延续不会继承协调器内部创建的 AsyncLocalStorage 上下文。
+ * 因此不能靠“遇到 BEGIN 后一直持锁”猜测后续 COMMIT 属于谁，只能要求使用具备对象身份的
+ * DataSource.transaction 或 QueryRunner 生命周期 API。
+ */
+const TRANSACTION_CONTROL_SQL_PATTERN =
+  /^(?:(?:\s+)|(?:;\s*)|(?:--[^\r\n]*(?:\r?\n|$))|(?:\/\*[\s\S]*?\*\/))*(?:BEGIN\b|START\s+TRANSACTION\b|COMMIT\b|END(?:\s+TRANSACTION)?\b|ROLLBACK\b|SAVEPOINT\b|RELEASE(?:\s+SAVEPOINT)?\b|SET\s+TRANSACTION\b)/i
+
+const isTransactionControlSql = (query: string): boolean => {
+  return TRANSACTION_CONTROL_SQL_PATTERN.test(query)
+}
+
 class BoundedSerialWriteQueue {
   private active = false
   private readonly pending: QueueEntry[] = []
@@ -227,6 +248,8 @@ export class TransactionCoordinator {
   private readonly writeQueue: BoundedSerialWriteQueue
   private installed = false
   private readonly wrappedQueryBuilders = new WeakSet<object>()
+  private readonly wrappedQueryRunners = new WeakSet<object>()
+  private readonly queryRunnerLeaseStates = new WeakMap<object, QueryRunnerLeaseState>()
 
   constructor(
     readonly dataSource: DataSource,
@@ -243,6 +266,7 @@ export class TransactionCoordinator {
       return
     }
     this.patchDataSourceTransaction()
+    this.patchDataSourceCreateQueryRunner()
     this.patchDataSourceQuery()
     this.patchDataSourceQueryBuilder()
     this.patchGlobalEntityManager()
@@ -264,12 +288,14 @@ export class TransactionCoordinator {
     }
 
     const release = await this.writeQueue.acquire()
+    const writeLeaseToken = Symbol('transaction-coordinator-write-lease')
     try {
       return await transactionContextStorage.run(
         {
           dataSource: this.dataSource,
           manager: activeContext?.dataSource === this.dataSource ? activeContext.manager : undefined,
           ownsWriteLease: true,
+          writeLeaseToken,
         },
         work,
       )
@@ -328,12 +354,19 @@ export class TransactionCoordinator {
       }
 
       return this.runExclusive(async () => {
+        const writeLeaseContext = transactionContextStorage.getStore()
         const wrappedHandler: TransactionHandler = async (manager) => {
           return transactionContextStorage.run(
             {
               dataSource,
               manager,
-              ownsWriteLease: this.options.serializeWrites,
+              ownsWriteLease: Boolean(
+                writeLeaseContext?.dataSource === dataSource
+                && writeLeaseContext.ownsWriteLease,
+              ),
+              writeLeaseToken: writeLeaseContext?.dataSource === dataSource
+                ? writeLeaseContext.writeLeaseToken
+                : undefined,
             },
             () => handler(manager),
           )
@@ -343,6 +376,244 @@ export class TransactionCoordinator {
           : originalTransaction(isolationOrHandler, wrappedHandler)
       })
     }) as DataSource['transaction']
+  }
+
+  private createQueryRunnerFacade(queryRunner: QueryRunner): QueryRunner {
+    // TypeORM sqlite 驱动会让每次 createQueryRunner() 返回同一个实例。若直接在该实例上
+    // 记录租约，两个并发调用方会被误判成同一 QueryRunner 的嵌套事务。这里为每次调用
+    // 创建一个轻量逻辑门面：底层仍复用唯一 SQLite 连接，但事务深度、manager、广播器和
+    // 协调器租约均按调用方对象隔离，再由有界队列保证同一时刻只有一个门面进入事务。
+    const facade = Object.create(Object.getPrototypeOf(queryRunner)) as QueryRunner
+    const source = queryRunner as unknown as Record<string, unknown>
+    const target = facade as unknown as Record<string, unknown>
+    Object.assign(target, source, {
+      isReleased: false,
+      isTransactionActive: false,
+      data: {},
+      loadedTables: [],
+      loadedViews: [],
+      sqlMemoryMode: false,
+      transactionDepth: 0,
+      transactionPromise: null,
+      cachedTablePaths: {},
+    })
+
+    const sqlInMemory = source.sqlInMemory
+    if (sqlInMemory && typeof sqlInMemory === 'object') {
+      const SqlInMemoryConstructor = (sqlInMemory as { constructor: new () => unknown }).constructor
+      target.sqlInMemory = new SqlInMemoryConstructor()
+    }
+
+    const broadcaster = source.broadcaster
+    if (broadcaster && typeof broadcaster === 'object') {
+      const BroadcasterConstructor = (
+        broadcaster as { constructor: new (owner: QueryRunner) => unknown }
+      ).constructor
+      target.broadcaster = new BroadcasterConstructor(facade)
+    }
+
+    target.manager = this.dataSource.createEntityManager(facade)
+    return facade
+  }
+
+  private patchDataSourceCreateQueryRunner(): void {
+    const dataSource = this.dataSource
+    const originalCreateQueryRunner = dataSource.createQueryRunner.bind(dataSource) as DataSource['createQueryRunner']
+    dataSource.createQueryRunner = ((
+      ...args: Parameters<DataSource['createQueryRunner']>
+    ): QueryRunner => {
+      const queryRunner = originalCreateQueryRunner(...args)
+      return this.options.serializeWrites
+        ? this.wrapQueryRunner(this.createQueryRunnerFacade(queryRunner))
+        : queryRunner
+    }) as DataSource['createQueryRunner']
+  }
+
+  private async acquireQueryRunnerLease(state: QueryRunnerLeaseState): Promise<void> {
+    if (state.release || state.borrowedLeaseToken) {
+      return
+    }
+
+    const activeContext = transactionContextStorage.getStore()
+    if (
+      activeContext?.dataSource === this.dataSource
+      && activeContext.ownsWriteLease
+    ) {
+      if (!activeContext.writeLeaseToken) {
+        throw new Error('当前 SQLite 写租约缺少所有者标识，无法安全借给 QueryRunner')
+      }
+      state.borrowedLeaseToken = activeContext.writeLeaseToken
+      return
+    }
+
+    state.release = await this.writeQueue.acquire()
+  }
+
+  private releaseQueryRunnerLease(state: QueryRunnerLeaseState): void {
+    const release = state.release
+    state.release = undefined
+    state.borrowedLeaseToken = undefined
+    release?.()
+  }
+
+  private assertQueryRunnerLeaseAccess(state: QueryRunnerLeaseState): void {
+    if (!state.borrowedLeaseToken) {
+      return
+    }
+
+    const activeContext = transactionContextStorage.getStore()
+    if (
+      activeContext?.dataSource !== this.dataSource
+      || activeContext.writeLeaseToken !== state.borrowedLeaseToken
+    ) {
+      throw new Error(
+        'QueryRunner 事务已逃逸其所属的 SQLite 写租约上下文；'
+        + '请在同一个 transaction/runDatabaseExclusive 回调内完成提交、回滚或 release',
+      )
+    }
+  }
+
+  private async allowQueryRunnerTransactionControl<T>(
+    state: QueryRunnerLeaseState,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    state.allowedTransactionControlDepth += 1
+    try {
+      return await work()
+    } finally {
+      state.allowedTransactionControlDepth -= 1
+    }
+  }
+
+  private wrapQueryRunner(queryRunner: QueryRunner): QueryRunner {
+    if (!this.options.serializeWrites || this.wrappedQueryRunners.has(queryRunner)) {
+      return queryRunner
+    }
+
+    this.wrappedQueryRunners.add(queryRunner)
+    const state: QueryRunnerLeaseState = {
+      allowedTransactionControlDepth: 0,
+    }
+    this.queryRunnerLeaseStates.set(queryRunner, state)
+
+    const originalStartTransaction = queryRunner.startTransaction.bind(queryRunner)
+    const originalCommitTransaction = queryRunner.commitTransaction.bind(queryRunner)
+    const originalRollbackTransaction = queryRunner.rollbackTransaction.bind(queryRunner)
+    const originalRelease = queryRunner.release.bind(queryRunner)
+    const originalQuery = queryRunner.query.bind(queryRunner) as (
+      query: string,
+      parameters?: unknown[],
+      useStructuredResult?: boolean,
+    ) => Promise<unknown>
+
+    queryRunner.startTransaction = async (isolationLevel?: IsolationLevel): Promise<void> => {
+      const isRootTransaction = !state.release && !state.borrowedLeaseToken
+      if (isRootTransaction) {
+        await this.acquireQueryRunnerLease(state)
+      } else {
+        this.assertQueryRunnerLeaseAccess(state)
+      }
+
+      try {
+        await this.allowQueryRunnerTransactionControl(
+          state,
+          () => originalStartTransaction(isolationLevel),
+        )
+      } catch (error) {
+        // BeforeTransactionStart 或参数校验失败时数据库尚未进入事务，可立即归还租约。
+        // 若 BEGIN 已成功而后续广播失败，QueryRunner 仍处于活动态，保留租约并交给
+        // rollback/release 清理，不能为了避免队列卡住而让其它请求进入未结束事务。
+        if (isRootTransaction && !queryRunner.isTransactionActive) {
+          this.releaseQueryRunnerLease(state)
+        }
+        throw error
+      }
+    }
+
+    queryRunner.commitTransaction = async (): Promise<void> => {
+      this.assertQueryRunnerLeaseAccess(state)
+      try {
+        await this.allowQueryRunnerTransactionControl(state, originalCommitTransaction)
+      } finally {
+        if (!queryRunner.isTransactionActive) {
+          this.releaseQueryRunnerLease(state)
+        }
+      }
+    }
+
+    queryRunner.rollbackTransaction = async (): Promise<void> => {
+      this.assertQueryRunnerLeaseAccess(state)
+      try {
+        await this.allowQueryRunnerTransactionControl(state, originalRollbackTransaction)
+      } finally {
+        if (!queryRunner.isTransactionActive) {
+          this.releaseQueryRunnerLease(state)
+        }
+      }
+    }
+
+    queryRunner.release = async (): Promise<void> => {
+      let rollbackError: unknown
+      if (queryRunner.isTransactionActive && (state.release || state.borrowedLeaseToken)) {
+        try {
+          // release 是最后的异常清理边界。即使借入租约的回调已经逃逸，也必须优先
+          // 在同一 QueryRunner 上回滚，而不是把仍有活动事务的连接交还给后续请求。
+          await this.allowQueryRunnerTransactionControl(state, originalRollbackTransaction)
+        } catch (error) {
+          rollbackError = error
+        }
+        if (queryRunner.isTransactionActive) {
+          throw new Error(
+            'QueryRunner.release 无法回滚仍在活动的 SQLite 事务，写租约已保留以阻止数据交错',
+            { cause: rollbackError },
+          )
+        }
+      }
+
+      try {
+        await originalRelease()
+      } finally {
+        if (!queryRunner.isTransactionActive) {
+          this.releaseQueryRunnerLease(state)
+        }
+      }
+
+      if (rollbackError) {
+        throw rollbackError
+      }
+    }
+
+    queryRunner.query = (async (
+      query: string,
+      parameters?: unknown[],
+      useStructuredResult?: boolean,
+    ): Promise<unknown> => {
+      if (
+        state.allowedTransactionControlDepth === 0
+        && isTransactionControlSql(query)
+      ) {
+        throw new Error(
+          '禁止通过 QueryRunner.query 直接控制事务边界；'
+          + '请使用 startTransaction/commitTransaction/rollbackTransaction，以便协调器跨语句持有写租约',
+        )
+      }
+
+      const execute = () => originalQuery(query, parameters, useStructuredResult)
+      if (state.release) {
+        return execute()
+      }
+      if (state.borrowedLeaseToken) {
+        // 生命周期方法内部会临时放行 TypeORM 自己发出的 BEGIN/COMMIT/ROLLBACK，
+        // 普通调用则必须仍处在借出租约的同一异步上下文中。
+        if (state.allowedTransactionControlDepth === 0) {
+          this.assertQueryRunnerLeaseAccess(state)
+        }
+        return execute()
+      }
+      return this.runExclusive(execute)
+    }) as QueryRunner['query']
+
+    return queryRunner
   }
 
   private patchDataSourceQuery(): void {
@@ -357,6 +628,12 @@ export class TransactionCoordinator {
       parameters?: unknown[],
       queryRunner?: unknown,
     ): Promise<unknown> => {
+      if (this.options.serializeWrites && isTransactionControlSql(query)) {
+        throw new Error(
+          '禁止通过 DataSource.query 直接控制事务边界；'
+          + '请使用 DataSource.transaction，或使用由 createQueryRunner 创建的 QueryRunner 生命周期 API',
+        )
+      }
       const activeContext = transactionContextStorage.getStore()
       if (
         !queryRunner
@@ -367,6 +644,15 @@ export class TransactionCoordinator {
         // 将看不到未提交写入并逃逸当前事务。统一委派给当前 manager，
         // 与 Repository/QueryBuilder 的兼容兜底保持同一隔离边界。
         return activeContext.manager.query(query, parameters)
+      }
+      if (queryRunner) {
+        // EntityManager.query 会把自身 QueryRunner 作为第三参回传给 DataSource.query。
+        // 该 QueryRunner 已按对象身份持有整段事务租约，不能再按单条语句入队，否则会等待自己而死锁。
+        return originalQuery(
+          query,
+          parameters,
+          this.wrapQueryRunner(queryRunner as QueryRunner),
+        )
       }
       const execute = () => originalQuery(query, parameters, queryRunner)
       // TypeORM sqlite 驱动在一个 DataSource 内复用单 QueryRunner/连接。
@@ -459,7 +745,21 @@ export class TransactionCoordinator {
         continue
       }
       queryBuilder[methodName] = (...args: unknown[]) => {
-        return this.runExclusive(async () => originalTerminal.apply(value, args))
+        const execute = async () => originalTerminal.apply(value, args)
+        // QueryRunner.manager.createQueryBuilder 会把已持有事务租约的 QueryRunner 注入 builder。
+        // 若这里再按 terminal 单独排队，builder 会等待自己的长事务租约而死锁。
+        const queryRunner = queryBuilder.queryRunner
+        if (queryRunner && typeof queryRunner === 'object') {
+          const state = this.queryRunnerLeaseStates.get(queryRunner)
+          if (state?.release) {
+            return execute()
+          }
+          if (state?.borrowedLeaseToken) {
+            this.assertQueryRunnerLeaseAccess(state)
+            return execute()
+          }
+        }
+        return this.runExclusive(execute)
       }
     }
 

--- a/docs/project-context/41-后端启动、路由装配与健康检查.md
+++ b/docs/project-context/41-后端启动、路由装配与健康检查.md
@@ -45,7 +45,8 @@
 - `/health` 只返回 `status` 与脱敏维护态，不返回数据库拓扑、队列指标或运行时覆盖详情。
 - 管理员接口 `GET /api/data-maintenance/database/performance` 返回数据库引擎能力与写协调器水位；运行时覆盖详情由 `GET /api/data-maintenance/db-migration/runtime-override` 提供。
 - 真正生效的数据库模式可能来自环境变量，也可能来自运行时覆盖配置。
-- SQLite 模式下所有受协调的写入共用有界单写队列；`pendingWrites/rejectedWrites/timedOutWrites` 用于判断是否需要迁移 MySQL。
+- SQLite 模式下所有受协调的写入共用有界单写队列；`DataSource.transaction` 与 `QueryRunner` 都按完整事务持有租约，`pendingWrites/rejectedWrites/timedOutWrites` 用于判断是否需要迁移 MySQL。
+- 禁止通过 `DataSource.query` 或 `QueryRunner.query` 直接发送 `BEGIN/COMMIT/ROLLBACK/SAVEPOINT` 等事务控制 SQL：跨多次 `DataSource.query` 调用无法可靠识别事务所有者，应改用回调事务或 QueryRunner 生命周期 API。
 - MySQL 模式在 HTTP 监听和后台 Worker 启动前校验关键表、增量字段及索引形状；存量库漏执行 `035/036` 时会给出目标脚本并阻止启动。
 
 ## 权限与安全边界
@@ -59,10 +60,10 @@
 1. 服务起不来：先看 `backend/src/index.ts` 的启动阶段日志卡在哪一环。
 2. `/health` 可访问但业务不对：用管理员数据库性能接口和运行时覆盖接口确认当前进程实际连接的数据库模式。
 3. 本地和线上表现不一致：对比 `app.ts` 的路由挂载顺序与部署方式。
-4. SQLite 模式偶发锁问题：先看管理员数据库性能接口中的 `writeCoordinator` 队深、拒绝和超时，再看业务事务是否过大、数据库是否位于本地持久化磁盘。
+4. SQLite 模式偶发锁问题：先看管理员数据库性能接口中的 `writeCoordinator` 队深、拒绝和超时，再看业务事务是否过大、是否绕开受支持事务 API、数据库是否位于本地持久化磁盘。
 5. MySQL 升级后启动提示结构不完整：按错误列出的结构对象只执行对应增量脚本；`036` 必须先停止所有应用和通知 Worker，不能通过开启实体同步绕过存量库迁移。
 
 ## 验证与回归关注点
 
 - 改启动或装配逻辑后至少回归：后端可启动、`/health` 返回正常、管理端登录和客户端匿名商品接口正常。
-- 改数据库模式相关逻辑后回归：公开 `/health` 脱敏约束、管理员数据库性能接口、运行时覆盖状态与对应验证脚本。
+- 改数据库模式或事务协调逻辑后回归：`transaction-coordinator:verify`、公开 `/health` 脱敏约束、管理员数据库性能接口、运行时覆盖状态与对应验证脚本。

--- a/docs/project-context/52-验证脚本与高风险操作.md
+++ b/docs/project-context/52-验证脚本与高风险操作.md
@@ -31,6 +31,9 @@
 ## 后端链路
 
 - 后端 TypeScript 改动后，应跑 `npm --prefix backend run build`。
+- SQLite 事务协调器、`DataSource.transaction/query` 或 `QueryRunner` 接管逻辑改动后，应跑：
+  - `npm --prefix backend run transaction-coordinator:verify`
+  - `npm --prefix backend run task8:verify`
 - SQLite -> MySQL 自动迁移、维护只读屏障、运行时切换或 onebox 重启改动后，必须跑：
   - `npm run verify:db:migration:timeout`
   - `npm run verify:db:migration`
@@ -114,6 +117,7 @@ CI 入口为 `.github/workflows/database-migration-e2e.yml`：18 个场景划分
 - 文档/规则改动：`npm run verify:text-encoding`
 - 前端结构改动：`npm run build`
 - 后端结构改动：`npm --prefix backend run build`
+- SQLite 事务协调器改动：`npm --prefix backend run transaction-coordinator:verify` + `npm --prefix backend run task8:verify`
 - 数据库自动迁移/onebox 切换：`npm run verify:db:migration`
 - 权限/路由/安全改动：后端契约与安全验证脚本
 - 大型重构：性能验证

--- a/docs/后端路由服务事务审计规范.md
+++ b/docs/后端路由服务事务审计规范.md
@@ -55,6 +55,9 @@
   - 先校验，再写入
   - 所有关键仓储共用同一 `manager`
   - 失败时不留下半成功脏数据
+- 服务层默认使用 `runInTransaction` 或 `DataSource.transaction` 回调边界；确需手动控制连接时，可使用 `createQueryRunner()`，但必须用 `startTransaction/commitTransaction/rollbackTransaction/release` 完整收口。
+- 禁止通过 `DataSource.query` 或 `QueryRunner.query` 直接发送 `BEGIN`、`COMMIT`、`ROLLBACK`、`SAVEPOINT` 等事务控制 SQL。SQLite 单连接下无法在多次异步调用之间安全判断事务所有者，协调器会在运行时拒绝这类写法。
+- `QueryRunner.release()` 是异常清理边界：存在未结束事务时会先回滚；若回滚失败，协调器会保留租约并阻断后续写入，避免把活动事务连接交给其它请求。
 
 ## 6. 审计规范
 - 以下写操作必须有审计：

--- a/scripts/verify-unit-functional-suite.mjs
+++ b/scripts/verify-unit-functional-suite.mjs
@@ -86,6 +86,11 @@ const main = async () => {
   // - 防止系统配置页新增白名单治理后，后续改动把目录接口或权限链路悄悄带坏。
   await runNpmScript('后端教职工目录治理回归', 'client-staff-directory:verify', backendRoot)
 
+  // SQLite 事务协调器入口覆盖：
+  // - QueryRunner.startTransaction 必须跨多条语句持有同一有界写租约；
+  // - release 必须回滚未结束事务，原始 BEGIN/COMMIT/ROLLBACK SQL 必须被运行时拒绝。
+  await runNpmScript('后端 SQLite 事务协调器入口覆盖回归', 'transaction-coordinator:verify', backendRoot)
+
   // 双流水单号与 SQLite 并发写事务回归：
   // - 并发提交 16 笔出库单，守住 issue #36 修复的写事务串行化——若写事务绕过
   //   `runInTransaction` 闸门直接调用 `AppDataSource.transaction`，这一步会立刻失败；


### PR DESCRIPTION
## 修复内容

Issue #41 的根因有两层：`DataSource.query` 只能按单条语句排队，无法在多个 `await` 之间可靠识别原始 SQL 事务的所有者；同时 SQLite 驱动会让多次 `createQueryRunner()` 复用同一底层实例，原协调器完全没有接管这条路径。

- 为每次 `createQueryRunner()` 创建独立逻辑事务门面，底层仍复用 SQLite 单连接，但 manager、事务深度、广播器和租约所有者彼此隔离；
- `startTransaction` 获取租约并跨语句持有，最外层 `commitTransaction` / `rollbackTransaction` 后释放；嵌套 savepoint 继续持有外层租约；
- `release()` 遇到未完成事务时先回滚；回滚失败则保留租约，避免把活动事务连接交给其它请求；
- 运行时拒绝通过 `DataSource.query` / `QueryRunner.query` 发送 `BEGIN`、`COMMIT`、`ROLLBACK`、`SAVEPOINT` 等事务控制 SQL，改用回调事务或 QueryRunner 生命周期 API；
- 新增独立 SQLite 回归脚本，并接入数据库并发工作流与单元功能聚合套件；同步更新 #40 的静态门禁白名单、说明和相关事务文档。

该修复不修改实体、数据库结构、SQL 迁移、审计规则或前端类型。

## 验证

- `node --import tsx backend/scripts/write-transaction-contract-verify.ts`
- `npm --prefix backend run transaction-coordinator:verify`
- `npm --prefix backend run build`
- `node --import tsx backend/scripts/task8-verify.ts`（16 笔并发出库回归通过）
- SQLite 数据库并发验收：16 项检查通过、0 项失败
- `npm run verify:text-encoding`
- GitHub Actions YAML 解析校验通过

本地压力验收曾有一次在沙箱高负载下触发既有 7.5 秒队列超时；未改代码立即复跑后 16/16 通过，最终各场景均为 0 个非预期错误。

Closes #41