### PR TITLE
fix(auth): 修复容器验证码缺字并优化验证输入体验

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "mysql2": "^3.15.2",
         "reflect-metadata": "^0.2.2",
         "sharp": "^0.35.3",
+        "svg-captcha": "1.4.0",
         "typeorm": "^0.3.29",
         "uuid": "^11.1.1",
         "zod": "^3.25.76"
@@ -3967,6 +3968,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opentype.js": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.7.3.tgz",
+      "integrity": "sha512-Veui5vl2bLonFJ/SjX/WRWJT3SncgiZNnKUyahmXCc2sa1xXW15u3R/3TN5+JFiP7RsjK5ER4HA5eWaEmV9deA==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.2"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4878,6 +4891,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/svg-captcha": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/svg-captcha/-/svg-captcha-1.4.0.tgz",
+      "integrity": "sha512-/fkkhavXPE57zRRCjNqAP3txRCSncpMx3NnNZL7iEoyAtYwUjPhJxW6FQTQPG5UPEmCrbFoXS10C3YdJlW7PDg==",
+      "license": "MIT",
+      "dependencies": {
+        "opentype.js": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.22",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
@@ -4930,6 +4955,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "release:verify": "tsx scripts/release-full-regression-verify.ts",
     "security:hardening:verify": "tsx scripts/security-hardening-verify.ts",
     "security:auth-depth:verify": "node --import tsx scripts/security-hardening-auth-verify.ts",
+    "captcha:rendering:verify": "node --import tsx scripts/captcha-rendering-verify.ts",
     "security:auth-sse-final:verify": "node --import tsx scripts/auth-sse-final-regression-verify.ts",
     "security:http-boundary:verify": "node --import tsx scripts/http-security-verify.ts",
     "security:business-boundary:verify": "node --import tsx scripts/security-business-contract-verify.ts",
@@ -89,6 +90,7 @@
     "mysql2": "^3.15.2",
     "reflect-metadata": "^0.2.2",
     "sharp": "^0.35.3",
+    "svg-captcha": "1.4.0",
     "typeorm": "^0.3.29",
     "uuid": "^11.1.1",
     "zod": "^3.25.76"

--- a/backend/scripts/captcha-rendering-verify.ts
+++ b/backend/scripts/captcha-rendering-verify.ts
@@ -1,0 +1,60 @@
+/**
+ * 文件说明：在空字体目录环境中验证真实 PNG 验证码，防止精简镜像只显示干扰线或缺字方框。
+ * 实现逻辑：子进程在加载 sharp 前指定独立 Fontconfig 配置，检查全部随机字符的六个位置、图像兼容与票据校验。
+ */
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+if (!process.argv.includes('--no-fonts-worker')) {
+  const directory = mkdtempSync(join(tmpdir(), 'ylink-captcha-fontless-'))
+  const configPath = join(directory, 'fonts.conf')
+  writeFileSync(configPath, '<?xml version="1.0"?><!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd"><fontconfig></fontconfig>')
+  const result = spawnSync(process.execPath, ['--import', 'tsx', fileURLToPath(import.meta.url), '--no-fonts-worker'], {
+    env: { ...process.env, FONTCONFIG_FILE: configPath, FONTCONFIG_PATH: directory },
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  assert.equal(result.status, 0, '无系统字体的验证码回归必须通过')
+} else {
+  const { default: sharp } = await import('sharp')
+  const { CaptchaService } = await import('../src/services/captcha.service.js')
+  const renderedImages = new Set<string>()
+  // 同时覆盖现有测试注入的 0、1、I、O；生产随机字母表仍排除易混淆字符。
+  for (const char of 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') {
+    const code = char.repeat(6)
+    const service = new CaptchaService({ createCode: () => code })
+    const ticket = await service.createCaptcha('client')
+    assert.match(ticket.captchaImage, /^data:image\/png;base64,/)
+    assert.match(ticket.captchaSvg, /<image\b/)
+    assert.doesNotMatch(ticket.captchaSvg, /<(?:text|path)\b/, '兼容 SVG 只能包含栅格图像')
+    assert.ok(!JSON.stringify(ticket).includes(code), '响应不得带有答案明文')
+    assert.ok(!renderedImages.has(ticket.captchaImage), '不同字符不得被渲染为相同的缺字方框')
+    renderedImages.add(ticket.captchaImage)
+    const png = Buffer.from(ticket.captchaImage.split(',')[1]!, 'base64')
+    const { data, info } = await sharp(png).flatten({ background: '#ffffff' }).raw().toBuffer({ resolveWithObject: true })
+    assert.equal(info.width, 140)
+    assert.equal(info.height, 40)
+    for (let index = 0; index < 6; index += 1) {
+      let foregroundPixels = 0
+      for (let y = 5; y < 35; y += 1) {
+        for (let x = 10 + index * 20; x < 30 + index * 20; x += 1) {
+          const offset = (y * info.width + x) * info.channels
+          // 统计与浅色背景有明显对比的笔画，包含包内轮廓字体的抗锯齿边缘。
+          if (data[offset]! < 200 && data[offset + 1]! < 200 && data[offset + 2]! < 200) foregroundPixels += 1
+        }
+      }
+      assert.ok(foregroundPixels >= 35, `字符 ${char} 的第 ${index + 1} 位不可见：仅 ${foregroundPixels} 个前景像素`)
+    }
+    assert.throws(() => service.verifyCaptcha('admin', ticket.captchaId, code), /失效/)
+    assert.throws(() => service.verifyCaptcha('client', ticket.captchaId, 'wrong'), /错误/)
+    service.verifyCaptcha('client', ticket.captchaId, ` ${code.toLowerCase()} `)
+    assert.throws(() => service.verifyCaptcha('client', ticket.captchaId, code), /失效/)
+    const adminTicket = await service.createCaptcha('admin')
+    service.verifyCaptcha('admin', adminTicket.captchaId, code)
+  }
+  console.log('验证码无字体渲染验证通过：36 种字符 × 6 个位置、PNG/SVG 兼容、作用域隔离与一次性校验')
+}

--- a/backend/src/services/captcha.service.ts
+++ b/backend/src/services/captcha.service.ts
@@ -1,11 +1,12 @@
 /**
  * 文件说明：图形验证码服务，负责生成不可从响应文本还原答案的 PNG 验证码并校验一次性票据。
- * 实现逻辑：管理端与客户端使用独立、有界的票据存储；保留 SVG 字段仅作为 PNG 图像包装，兼容旧前端消费方式。
+ * 实现逻辑：svg-captcha 使用包内字体生成字形路径，sharp 栅格化后输出 PNG；管理端与客户端使用独立、有界的票据存储。
  * 维护说明：测试应通过构造函数注入固定验证码和渲染器，禁止从 HTTP 响应的图像或 SVG 文本反推出答案。
  */
 
 import { randomBytes, randomUUID } from 'node:crypto'
 import sharp from 'sharp'
+import svgCaptcha from 'svg-captcha'
 import { BizError } from '../utils/errors.js'
 import { EphemeralTicketStore } from '../utils/ephemeral-ticket-store.js'
 
@@ -37,34 +38,25 @@ const randomCaptchaCode = () => {
   return Array.from(buffer).map((item) => alphabet[item % alphabet.length]).join('')
 }
 
-const buildCaptchaSvg = (code: string) => {
-  const chars = code.split('')
-  const noiseLines = Array.from({ length: 5 }, (_, index) => {
-    const startX = 8 + index * 24
-    const startY = 10 + (index % 2 === 0 ? 4 : 16)
-    const endX = startX + 28
-    const endY = startY + (index % 2 === 0 ? 12 : -10)
-    return `<path d="M${startX} ${startY} L${endX} ${endY}" stroke="rgba(13,148,136,0.22)" stroke-width="1.5" stroke-linecap="round"/>`
-  }).join('')
-  const noiseDots = Array.from({ length: 12 }, (_, index) => {
-    const cx = 10 + ((index * 11) % 120)
-    const cy = 8 + ((index * 7) % 24)
-    const radius = index % 3 === 0 ? 1.4 : 1
-    return `<circle cx="${cx}" cy="${cy}" r="${radius}" fill="rgba(15,23,42,0.16)"/>`
-  }).join('')
-  const labels = chars
-    .map((char, index) => {
-      const x = 18 + index * 18
-      const y = 27 + (index % 2 === 0 ? -2 : 3)
-      const rotate = index % 2 === 0 ? -8 : 7
-      const color = index % 2 === 0 ? '#0f766e' : '#0f172a'
-      return `<text x="${x}" y="${y}" font-size="20" fill="${color}" font-family="Arial, Helvetica, sans-serif" font-weight="700" transform="rotate(${rotate} ${x} ${y})">${char}</text>`
-    })
-    .join('')
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="140" height="40" viewBox="0 0 140 40" role="img" aria-label="图形验证码"><defs><linearGradient id="captcha-bg" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f8fafc"/><stop offset="100%" stop-color="#d1fae5"/></linearGradient></defs><rect width="140" height="40" rx="10" fill="url(#captcha-bg)"/>${noiseLines}${noiseDots}${labels}</svg>`
-}
+// 包的公开函数支持指定答案，但其类型声明仅覆盖 create 等属性；在此补齐调用签名。
+// 答案继续使用 node:crypto 生成，字形、扰动和干扰线全部交由开源包处理。
+const createSvgCaptcha = svgCaptcha as typeof svgCaptcha & (
+  (text: string, options: Parameters<typeof svgCaptcha.create>[0]) => string
+)
 
-const renderCaptchaPng: CaptchaRenderer = async (svg) => sharp(Buffer.from(svg)).png().toBuffer()
+const buildCaptchaSvg = (code: string) => createSvgCaptcha(code, {
+  width: 140,
+  height: 40,
+  fontSize: 40,
+  noise: 1,
+  color: false,
+  background: '',
+})
+
+const renderCaptchaPng: CaptchaRenderer = async (svg) => sharp(Buffer.from(svg))
+  .flatten({ background: '#ecfdf5' })
+  .png()
+  .toBuffer()
 
 const wrapPngAsSvg = (pngDataUrl: string) => (
   `<svg xmlns="http://www.w3.org/2000/svg" width="140" height="40" viewBox="0 0 140 40" role="img" aria-label="图形验证码"><image width="140" height="40" href="${pngDataUrl}"/></svg>`

--- a/docs/project-context/42-权限、Cookie、CSRF、审计与上传安全.md
+++ b/docs/project-context/42-权限、Cookie、CSRF、审计与上传安全.md
@@ -36,6 +36,7 @@
 - `requireAdminCsrf` 仅对管理端非安全方法请求生效，且仅在 Cookie 会话来源下校验。
 - `requireRole` 和 `requirePermission` 在拒绝请求时会写安全审计。
 - `app.ts` 会给上传资源附加长期缓存、安全头和旧路径兼容重写逻辑。
+- 管理端与客户端图形验证码由 `captcha.service.ts` 共用生成链路：`svg-captcha` 使用包内字体绘制字符路径，`sharp` 转为 140×40 PNG，不依赖容器系统字体。答案仍由 `node:crypto` 生成；旧 `captchaSvg` 字段仅包装 PNG，不返回答案文本或字形路径。
 
 ## 代理、HTTPS 与救援传输边界
 
@@ -72,3 +73,4 @@
 - 改权限或鉴权时回归：登录、刷新恢复、写操作、越权拦截、审计记录。
 - 改上传安全时回归：新图片可访问、旧图片兼容访问、响应头正确。
 - 改 CSRF 时回归：管理端写接口在 Cookie 会话下的正常提交与失败提示。
+- 改图形验证码时执行 `npm --prefix backend run captcha:rendering:verify`，覆盖无系统字体的真实 PNG 渲染、兼容字段、作用域隔离和一次性校验。

--- a/src/views/client/ClientAuthView.vue
+++ b/src/views/client/ClientAuthView.vue
@@ -61,6 +61,7 @@
 /**
  * 模块说明：src/views/client/ClientAuthView.vue
  * 文件职责：客户端登录/注册总入口，负责账号登录、注册、验证码刷新与登录后回跳。
+ * 实现逻辑：复用认证 Store 与稳定请求处理登录注册；验证码行统一居中对齐，联系方式验证行通过网格展开和淡入平滑切换。
  * 维护说明：当前页面已切换为 Split-Card 一体化布局，视觉可继续调整，但登录/注册/验证码链路需保持可用。
  */
 
@@ -1414,26 +1415,35 @@ onUnmounted(() => {
                     </button>
                   </div>
                   <p v-if="!isDepartmentRegisterMode" class="captcha-hint-text">{{ captchaHintText }}</p>
-                  <div v-if="!isDepartmentRegisterMode && registerUsesVerificationCode" class="captcha-row">
-                    <el-input v-model="registerForm.verificationCode" placeholder="手机/邮箱验证码" class="geo-input flex-1" size="large" clearable>
-                      <template #prefix>
-                        <el-icon class="input-icon"><Message /></el-icon>
-                      </template>
-                    </el-input>
-                    <el-button
-                      class="verification-code-button"
-                      :disabled="verificationSending || registerVerificationCountdown > 0"
-                      @click="handleSendRegisterVerificationCode"
+                  <Transition name="verification-code">
+                    <div
+                      v-if="!isDepartmentRegisterMode && registerUsesVerificationCode"
+                      class="verification-code-reveal"
                     >
-                      {{
-                        registerVerificationCountdown > 0
-                          ? `${registerVerificationCountdown}s 后重发`
-                          : verificationSending
-                            ? '发送中'
-                            : '发送验证码'
-                      }}
-                    </el-button>
-                  </div>
+                      <div class="verification-code-reveal__inner">
+                        <div class="captcha-row">
+                          <el-input v-model="registerForm.verificationCode" placeholder="手机/邮箱验证码" class="geo-input flex-1" size="large" clearable>
+                            <template #prefix>
+                              <el-icon class="input-icon"><Message /></el-icon>
+                            </template>
+                          </el-input>
+                          <el-button
+                            class="verification-code-button"
+                            :disabled="verificationSending || registerVerificationCountdown > 0"
+                            @click="handleSendRegisterVerificationCode"
+                          >
+                            {{
+                              registerVerificationCountdown > 0
+                                ? `${registerVerificationCountdown}s 后重发`
+                                : verificationSending
+                                  ? '发送中'
+                                  : '发送验证码'
+                            }}
+                          </el-button>
+                        </div>
+                      </div>
+                    </div>
+                  </Transition>
 
                   <el-input
                     v-model="registerForm.password"
@@ -1589,26 +1599,35 @@ onUnmounted(() => {
                     </button>
                   </div>
                   <p v-if="!isDepartmentRegisterMode" class="captcha-hint-text">{{ captchaHintText }}</p>
-                  <div v-if="!isDepartmentRegisterMode && registerUsesVerificationCode" class="captcha-row">
-                    <el-input v-model="registerForm.verificationCode" placeholder="手机/邮箱验证码" class="geo-input flex-1" size="large" clearable>
-                      <template #prefix>
-                        <el-icon class="input-icon"><Message /></el-icon>
-                      </template>
-                    </el-input>
-                    <el-button
-                      class="verification-code-button"
-                      :disabled="verificationSending || registerVerificationCountdown > 0"
-                      @click="handleSendRegisterVerificationCode"
+                  <Transition name="verification-code">
+                    <div
+                      v-if="!isDepartmentRegisterMode && registerUsesVerificationCode"
+                      class="verification-code-reveal"
                     >
-                      {{
-                        registerVerificationCountdown > 0
-                          ? `${registerVerificationCountdown}s 后重发`
-                          : verificationSending
-                            ? '发送中'
-                            : '发送验证码'
-                      }}
-                    </el-button>
-                  </div>
+                      <div class="verification-code-reveal__inner">
+                        <div class="captcha-row">
+                          <el-input v-model="registerForm.verificationCode" placeholder="手机/邮箱验证码" class="geo-input flex-1" size="large" clearable>
+                            <template #prefix>
+                              <el-icon class="input-icon"><Message /></el-icon>
+                            </template>
+                          </el-input>
+                          <el-button
+                            class="verification-code-button"
+                            :disabled="verificationSending || registerVerificationCountdown > 0"
+                            @click="handleSendRegisterVerificationCode"
+                          >
+                            {{
+                              registerVerificationCountdown > 0
+                                ? `${registerVerificationCountdown}s 后重发`
+                                : verificationSending
+                                  ? '发送中'
+                                  : '发送验证码'
+                            }}
+                          </el-button>
+                        </div>
+                      </div>
+                    </div>
+                  </Transition>
 
                   <el-input
                     v-model="registerForm.password"
@@ -2583,7 +2602,38 @@ onUnmounted(() => {
 
 .captcha-row {
   display: flex;
+  align-items: center;
   gap: 12px;
+}
+
+/* 保留自然内容高度，展开时同步推动下方表单，避免淡入后布局仍然瞬移。 */
+.verification-code-reveal {
+  display: grid;
+  grid-template-rows: 1fr;
+}
+
+.verification-code-reveal__inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.verification-code-enter-active,
+.verification-code-leave-active {
+  transition:
+    grid-template-rows 0.28s cubic-bezier(0.25, 1, 0.5, 1),
+    margin-top 0.28s cubic-bezier(0.25, 1, 0.5, 1),
+    opacity 0.2s ease;
+}
+
+.verification-code-leave-active {
+  pointer-events: none;
+}
+
+.form-block .verification-code-enter-from,
+.form-block .verification-code-leave-to {
+  grid-template-rows: 0fr;
+  margin-top: 0;
+  opacity: 0;
 }
 
 .captcha-row--placeholder {
@@ -2892,7 +2942,7 @@ onUnmounted(() => {
     transform: none !important;
   }
 
-  :is(.geo-fade-enter-from, .geo-fade-leave-to, .auth-fade-enter-from, .auth-fade-leave-to, .staff-lookup-enter-from, .staff-lookup-leave-to),
+  :is(.geo-fade-enter-from, .geo-fade-leave-to, .auth-fade-enter-from, .auth-fade-leave-to, .staff-lookup-enter-from, .staff-lookup-leave-to, .verification-code-enter-from, .verification-code-leave-to),
   :is(.staff-lookup-enter-from, .staff-lookup-leave-to) .staff-lookup-card {
     filter: none !important;
     grid-template-rows: 1fr !important;


### PR DESCRIPTION
## 问题与结果

精简 Docker 镜像缺少系统字体时，原验证码 SVG 的文本无法被渲染，导致页面只显示背景或干扰线。客户端在识别手机号/邮箱后，验证码输入行会突然出现，发送按钮也未在行内纵向居中。

本 PR 改用成熟开源库 svg-captcha 生成字形，并将验证码转换为 PNG；客户端验证输入行改为平滑展开，按钮在同一行内居中显示。

## 主要变更

- 使用 svg-captcha@1.4.0 的包内字体生成字符路径，保留 node:crypto 生成答案、PNG 响应、兼容 captchaSvg 字段、五分钟过期、作用域隔离和一次性校验。
- 新增无系统字体渲染回归脚本，覆盖 36 种字符的 6 个位置、PNG/SVG 兼容性及票据校验。
- 为注册表单的手机/邮箱验证码输入行增加网格展开与淡入过渡，兼容减少动态效果设置；发送验证码按钮与输入框纵向居中。
- 同步验证码生成与回归命令的项目上下文说明。

## 验证

- npm --prefix backend run captcha:rendering:verify
- npm --prefix backend run build
- npm --prefix backend run security:auth-depth:verify
- npm --prefix backend run security:hardening:verify
- npm run build
- npm run verify:text-encoding
- npm run verify:client-registration-policy
- 基于 backend/Dockerfile 的无系统字体容器验证：编译后的 CaptchaService 检查 36 种字符 × 6 个位置均可见。
- 真实临时 Docker 后端与浏览器联调：桌面端和移动端各刷新验证码 3 次，图像均可见且每次刷新变化；浏览器控制台无错误。

## 影响与回滚

- 新增后端运行时依赖 svg-captcha，无需数据库迁移或新增部署配置。
- 本 PR 未部署生产环境；若需回滚，可回退本分支的两个提交。