### PR TITLE
feat(dashboard): 首页图表与榜单支持自定义时间区间，商品榜默认合并并可细分规格

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "task2:verify": "tsx scripts/task2-verify.ts",
     "task2:governance:verify": "tsx scripts/task2-governance-verify.ts",
     "task2:route-contract:verify": "tsx scripts/task2-route-permission-contract-verify.ts",
+    "dashboard:analytics:verify": "node --import tsx scripts/dashboard-analytics-verify.ts",
     "write-transaction:contract:verify": "tsx scripts/write-transaction-contract-verify.ts",
     "task3:verify": "tsx scripts/task3-verify.ts",
     "task4:verify": "tsx scripts/task4-verify.ts",

--- a/backend/scripts/dashboard-analytics-verify.ts
+++ b/backend/scripts/dashboard-analytics-verify.ts
@@ -273,7 +273,26 @@ async function main() {
       () => dashboardService.getAnalytics({ ...baseRange, orderType: 'unknown' }),
       /orderType 非法/,
     )
-    pass('空区间返回空榜单，非法起止时间与非法订单类型均有明确反馈')
+
+    // JS 的 Date 对“日越界”会静默进位（2026-02-31 -> 2026-03-03、2026-04-31 -> 2026-05-01），
+    // 只靠正则校验会让这类输入悄悄查到错误区间，因此必须回写比对后拒绝。
+    await assert.rejects(
+      () => dashboardService.getAnalytics({ startDate: '2026-02-31', endDate: RANGE_END }),
+      /不是有效日期/,
+    )
+    await assert.rejects(
+      () => dashboardService.getAnalytics({ startDate: RANGE_START, endDate: '2026-04-31' }),
+      /不是有效日期/,
+    )
+    // 饼图与下钻共用同一套日期解析，同样不能放过越界日期。
+    await assert.rejects(
+      () => dashboardService.getDashboardPieData({ startDate: '2025-11-31', endDate: RANGE_END }),
+      /不是有效日期/,
+    )
+    // 闰年合法日期不能被误伤。
+    const leapDayRange = await dashboardService.getAnalytics({ startDate: '2028-02-29', endDate: '2028-02-29' })
+    assert.equal(leapDayRange.range.startDate, '2028-02-29', '闰年 2 月 29 日属于合法日期，不应被拒绝')
+    pass('空区间返回空榜单，非法起止时间、越界日历日期与非法订单类型均有明确反馈')
 
     // ---- 7. 饼图：商品维度合并 + “其他”补齐总额与占比 ----
     const pieData = await dashboardService.getDashboardPieData({ ...baseRange })

--- a/backend/scripts/dashboard-analytics-verify.ts
+++ b/backend/scripts/dashboard-analytics-verify.ts
@@ -5,43 +5,76 @@
  * - 直接用仓储写入出库主单与明细，从而精确控制 createdAt 与 productNameSnapshot，
  *   模拟 O2O 核销写入的“商品名（规格）”快照与手工开单写入的纯商品名两种真实数据形态；
  * - 断言全部围绕 issue #60 的验收标准展开：跨年区间边界、合并数量等于各规格之和、先聚合再截断、空区间与非法区间反馈。
- * 维护说明：若调整看板统计口径、区间上限或规格解析规则，请同步更新本脚本断言。
+ * 维护说明：
+ * - 本脚本会造脏数据，因此必须跑在一次性的独立 SQLite 库上，跑完即删；
+ * - 数据源相关模块必须用 `await import()` 动态加载：ESM 的静态 import 会在模块体执行前完成求值，
+ *   若改回静态 import，下面几行 process.env 赋值就会晚于 env.ts / data-source.ts 的初始化而完全失效，
+ *   脚本会连到开发者的默认库 data/y-link.sqlite 上跑，既污染本地数据，DB_TYPE 为 mysql 时更会直接写进共享库；
+ * - 若调整看板统计口径、区间上限或规格解析规则，请同步更新本脚本断言。
  */
 
+import 'reflect-metadata'
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { initializeDatabaseSchemaIfNeeded } from '../src/config/database-bootstrap.js'
-import { AppDataSource } from '../src/config/data-source.js'
-import { env } from '../src/config/env.js'
-import { BizOutboundOrder } from '../src/entities/biz-outbound-order.entity.js'
-import { BizOutboundOrderItem } from '../src/entities/biz-outbound-order-item.entity.js'
-import { dashboardService } from '../src/services/dashboard.service.js'
-import { productService } from '../src/services/product.service.js'
-import { systemConfigService } from '../src/services/system-config.service.js'
+
+const currentFilePath = fileURLToPath(import.meta.url)
+const backendRoot = path.resolve(path.dirname(currentFilePath), '..')
+const runtimeRoot = path.resolve(backendRoot, 'data', 'local-dev')
+const verifySeed = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`
+const sqlitePath = path.resolve(runtimeRoot, `y-link.dashboard-analytics-verify.${verifySeed}.sqlite`)
+
+// 必须早于任何后端模块求值：把本次验证钉死在一次性独立库上，
+// 既不会删除开发者的业务库，也不会因为外部把 DB_TYPE 配成 mysql 而把脏数据写进共享库。
+process.env.APP_PROFILE = `dashboard-analytics-verify-${verifySeed}`
+process.env.DB_TYPE = 'sqlite'
+process.env.DB_SYNC = 'true'
+process.env.SQLITE_DB_PATH = sqlitePath
+
+type AppDataSourceRef = (typeof import('../src/config/data-source.js'))['AppDataSource']
+type BizOutboundOrderRef = (typeof import('../src/entities/biz-outbound-order.entity.js'))['BizOutboundOrder']
+type BizOutboundOrderItemRef = (typeof import('../src/entities/biz-outbound-order-item.entity.js'))['BizOutboundOrderItem']
+type DashboardServiceRef = (typeof import('../src/services/dashboard.service.js'))['dashboardService']
+type ProductServiceRef = (typeof import('../src/services/product.service.js'))['productService']
+type SystemConfigServiceRef = (typeof import('../src/services/system-config.service.js'))['systemConfigService']
+type InitializeSchemaRef = (typeof import('../src/config/database-bootstrap.js'))['initializeDatabaseSchemaIfNeeded']
+
+let AppDataSource: AppDataSourceRef
+let BizOutboundOrder: BizOutboundOrderRef
+let BizOutboundOrderItem: BizOutboundOrderItemRef
+let dashboardService: DashboardServiceRef
+let productService: ProductServiceRef
+let systemConfigService: SystemConfigServiceRef
+let initializeDatabaseSchemaIfNeeded: InitializeSchemaRef
+
+/** 必须在上面的 process.env 赋值之后调用，否则数据源会按默认配置初始化。 */
+const loadRuntimeModules = async () => {
+  const env = (await import('../src/config/env.js')).env
+  // 兜底断言：万一有人把上面的隔离逻辑改坏，也要在写入任何数据之前停下来，
+  // 而不是等到脚本把开发者的业务库或共享 MySQL 弄脏之后才发现。
+  assert.equal(env.DB_TYPE, 'sqlite', '区间分析验证只能跑在一次性 SQLite 库上')
+  assert.equal(
+    path.resolve(backendRoot, env.SQLITE_DB_PATH),
+    sqlitePath,
+    '区间分析验证的数据库未被隔离，拒绝在业务库上执行',
+  )
+
+  AppDataSource = (await import('../src/config/data-source.js')).AppDataSource
+  BizOutboundOrder = (await import('../src/entities/biz-outbound-order.entity.js')).BizOutboundOrder
+  BizOutboundOrderItem = (await import('../src/entities/biz-outbound-order-item.entity.js')).BizOutboundOrderItem
+  dashboardService = (await import('../src/services/dashboard.service.js')).dashboardService
+  productService = (await import('../src/services/product.service.js')).productService
+  systemConfigService = (await import('../src/services/system-config.service.js')).systemConfigService
+  initializeDatabaseSchemaIfNeeded = (await import('../src/config/database-bootstrap.js')).initializeDatabaseSchemaIfNeeded
+}
 
 function pass(title: string) {
   console.log(`✅ ${title}`)
 }
 
-const currentFilePath = fileURLToPath(import.meta.url)
-const backendRoot = path.resolve(path.dirname(currentFilePath), '..')
-
 const RANGE_START = '2025-12-01'
 const RANGE_END = '2026-08-31'
-
-function resetVerifyDatabase() {
-  if (env.DB_TYPE !== 'sqlite') {
-    return
-  }
-
-  const verifyDatabasePath = path.resolve(backendRoot, env.SQLITE_DB_PATH)
-  fs.mkdirSync(path.dirname(verifyDatabasePath), { recursive: true })
-  if (fs.existsSync(verifyDatabasePath)) {
-    fs.rmSync(verifyDatabasePath, { force: true })
-  }
-}
 
 let orderSequence = 0
 
@@ -111,7 +144,8 @@ async function seedOutboundOrder(input: {
 }
 
 async function main() {
-  resetVerifyDatabase()
+  fs.mkdirSync(runtimeRoot, { recursive: true })
+  await loadRuntimeModules()
 
   await AppDataSource.initialize()
   await initializeDatabaseSchemaIfNeeded(AppDataSource)
@@ -339,6 +373,8 @@ async function main() {
     if (AppDataSource.isInitialized) {
       await AppDataSource.destroy()
     }
+    // 一次性库跑完即删，避免 data/local-dev 下堆积验证残留。
+    fs.rmSync(sqlitePath, { force: true })
   }
 }
 

--- a/backend/scripts/dashboard-analytics-verify.ts
+++ b/backend/scripts/dashboard-analytics-verify.ts
@@ -228,6 +228,42 @@ async function main() {
     })
     pass('商品榜默认按商品合并，开启细分规格后可按款式区分且总量守恒')
 
+    // ---- 2.1 商品改名后，历史快照的规格仍要能独立解析 ----
+    // 改名后主表是“新名称”，而历史明细快照仍是“旧名称（规格）”，前缀对不上；
+    // 若解析依赖当前主名称，榜单会把整段旧商品名当成规格标签展示。
+    const renamedProduct = await productService.create({
+      productName: '旧款笔记本',
+      defaultPrice: 15,
+      isActive: true,
+    })
+    await seedOutboundOrder({
+      createdAt: new Date(2026, 3, 8, 10, 0, 0),
+      orderType: 'walkin',
+      items: [
+        { productId: renamedProduct.id, nameSnapshot: '旧款笔记本（红色）', qty: 2, unitPrice: 15 },
+        { productId: renamedProduct.id, nameSnapshot: '旧款笔记本', qty: 1, unitPrice: 15 },
+      ],
+    })
+    await productService.update(renamedProduct.id, { productName: '新款笔记本' })
+
+    const renamedAnalytics = await dashboardService.getAnalytics({
+      ...baseRange,
+      productSpecMode: 'spec',
+      productId: renamedProduct.id,
+      topN: 20,
+    })
+    assert.equal(renamedAnalytics.topProducts.length, 2, '改名商品的两条历史快照应各占一行')
+    renamedAnalytics.topProducts.forEach((item) => {
+      assert.equal(item.productName, '新款笔记本', '商品名应展示当前主表名称')
+    })
+    const renamedSpecLabels = renamedAnalytics.topProducts.map((item) => item.specLabel).sort()
+    assert.deepEqual(
+      renamedSpecLabels,
+      ['默认规格', '红色'].sort(),
+      '改名后规格应从快照末尾独立解析为“红色”，而不是把整段旧商品名当作规格',
+    )
+    pass('商品改名后历史快照的规格仍能独立解析，不会把旧商品名当成规格')
+
     // ---- 3. 先完整聚合再截断 Top N ----
     for (let index = 0; index < 12; index += 1) {
       const fillerProduct = await productService.create({
@@ -247,7 +283,8 @@ async function main() {
     assert.equal(topFive.topProducts[0]?.productId, canvasBag.id, '合并后数量最高的商品应排在第一')
     assert.equal(topFive.topProducts[0]?.totalQty, '15.00', '榜首数量应为该商品全部规格之和，而不是被截断后的单一规格')
     const topTwenty = await dashboardService.getAnalytics({ ...baseRange, topN: 20 })
-    assert.equal(topTwenty.topProducts.length, 14, 'Top 20 应返回区间内全部 14 个商品')
+    // 帆布包、马克杯、改名笔记本 + 12 个填充商品。
+    assert.equal(topTwenty.topProducts.length, 15, 'Top 20 应返回区间内全部 15 个商品')
     pass('Top N 截断发生在完整聚合之后，切换 5/10/20 均生效')
 
     // ---- 4. 指定商品筛选与 Top N 兜底 ----
@@ -337,8 +374,9 @@ async function main() {
     assert.ok(otherSlice, '分组数超过 8 时应补一片“其他”')
 
     const pieValueSum = pieData.productPie.reduce((sum, slice) => sum + Number(slice.value), 0)
-    // 区间内金额：帆布包 15*20 + 马克杯 4*30 + 12 个填充商品各 1*5 = 300 + 120 + 60
-    assert.equal(pieValueSum.toFixed(2), '480.00', '各分片金额之和应等于区间真实总额')
+    // 区间内金额：帆布包 15*20 + 马克杯 4*30 + 改名笔记本 3*15 + 12 个填充商品各 1*5
+    //           = 300 + 120 + 45 + 60
+    assert.equal(pieValueSum.toFixed(2), '525.00', '各分片金额之和应等于区间真实总额')
     const pieRatioSum = pieData.productPie.reduce((sum, slice) => sum + Number(slice.ratio), 0)
     assert.ok(Math.abs(pieRatioSum - 100) <= 0.05, `各分片占比之和应约等于 100%，实际为 ${pieRatioSum.toFixed(2)}`)
     assert.equal(pieData.range.startDate, RANGE_START)

--- a/backend/scripts/dashboard-analytics-verify.ts
+++ b/backend/scripts/dashboard-analytics-verify.ts
@@ -1,0 +1,332 @@
+/**
+ * 文件说明：backend/scripts/dashboard-analytics-verify.ts
+ * 文件职责：验证工作台首页区间分析接口的区间边界、商品榜合并/细分口径、Top N 截断顺序、饼图占比口径与非法入参反馈。
+ * 实现逻辑：
+ * - 直接用仓储写入出库主单与明细，从而精确控制 createdAt 与 productNameSnapshot，
+ *   模拟 O2O 核销写入的“商品名（规格）”快照与手工开单写入的纯商品名两种真实数据形态；
+ * - 断言全部围绕 issue #60 的验收标准展开：跨年区间边界、合并数量等于各规格之和、先聚合再截断、空区间与非法区间反馈。
+ * 维护说明：若调整看板统计口径、区间上限或规格解析规则，请同步更新本脚本断言。
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { initializeDatabaseSchemaIfNeeded } from '../src/config/database-bootstrap.js'
+import { AppDataSource } from '../src/config/data-source.js'
+import { env } from '../src/config/env.js'
+import { BizOutboundOrder } from '../src/entities/biz-outbound-order.entity.js'
+import { BizOutboundOrderItem } from '../src/entities/biz-outbound-order-item.entity.js'
+import { dashboardService } from '../src/services/dashboard.service.js'
+import { productService } from '../src/services/product.service.js'
+import { systemConfigService } from '../src/services/system-config.service.js'
+
+function pass(title: string) {
+  console.log(`✅ ${title}`)
+}
+
+const currentFilePath = fileURLToPath(import.meta.url)
+const backendRoot = path.resolve(path.dirname(currentFilePath), '..')
+
+const RANGE_START = '2025-12-01'
+const RANGE_END = '2026-08-31'
+
+function resetVerifyDatabase() {
+  if (env.DB_TYPE !== 'sqlite') {
+    return
+  }
+
+  const verifyDatabasePath = path.resolve(backendRoot, env.SQLITE_DB_PATH)
+  fs.mkdirSync(path.dirname(verifyDatabasePath), { recursive: true })
+  if (fs.existsSync(verifyDatabasePath)) {
+    fs.rmSync(verifyDatabasePath, { force: true })
+  }
+}
+
+let orderSequence = 0
+
+interface SeedItemInput {
+  productId: string
+  /** 出库明细名称快照：带“（规格）”后缀即模拟 O2O 核销单，纯商品名即模拟手工开单。 */
+  nameSnapshot: string
+  qty: number
+  unitPrice: number
+}
+
+/**
+ * 直接写入一张出库单：
+ * - createdAt 由 @CreateDateColumn 自动生成，因此写入后再显式回写为目标时刻；
+ * - 时刻使用本地时区构造，用于验证趋势分桶不会因 UTC 转换把凌晨单据算到前一天。
+ */
+async function seedOutboundOrder(input: {
+  createdAt: Date
+  orderType: 'walkin' | 'department'
+  departmentName?: string
+  items: SeedItemInput[]
+}) {
+  orderSequence += 1
+  const orderRepo = AppDataSource.getRepository(BizOutboundOrder)
+  const itemRepo = AppDataSource.getRepository(BizOutboundOrderItem)
+
+  const totalQty = input.items.reduce((sum, item) => sum + item.qty, 0)
+  const totalAmount = input.items.reduce((sum, item) => sum + item.qty * item.unitPrice, 0)
+
+  const order = await orderRepo.save(
+    orderRepo.create({
+      orderUuid: globalThis.crypto.randomUUID(),
+      showNo: `DA-VERIFY-${String(orderSequence).padStart(5, '0')}`,
+      orderType: input.orderType,
+      issuerName: '区间分析验证',
+      customerDepartmentName: input.departmentName ?? null,
+      customerName: input.orderType === 'walkin' ? '区间分析散客' : null,
+      idempotencyKey: `dashboard-analytics-verify-${orderSequence}`,
+      totalQty: totalQty.toFixed(2),
+      totalAmount: totalAmount.toFixed(2),
+      isDeleted: false,
+    }),
+  )
+
+  await orderRepo
+    .createQueryBuilder()
+    .update(BizOutboundOrder)
+    .set({ createdAt: input.createdAt })
+    .where('id = :id', { id: order.id })
+    .execute()
+
+  await itemRepo.save(
+    input.items.map((item, index) =>
+      itemRepo.create({
+        orderId: order.id,
+        lineNo: index + 1,
+        productId: item.productId,
+        productNameSnapshot: item.nameSnapshot,
+        qty: item.qty.toFixed(2),
+        unitPrice: item.unitPrice.toFixed(2),
+        lineAmount: (item.qty * item.unitPrice).toFixed(2),
+      }),
+    ),
+  )
+
+  return order
+}
+
+async function main() {
+  resetVerifyDatabase()
+
+  await AppDataSource.initialize()
+  await initializeDatabaseSchemaIfNeeded(AppDataSource)
+  await systemConfigService.ensureDefaultConfigs()
+
+  try {
+    const canvasBag = await productService.create({
+      productName: '帆布包',
+      defaultPrice: 20,
+      isActive: true,
+    })
+    const mug = await productService.create({
+      productName: '马克杯',
+      defaultPrice: 30,
+      isActive: true,
+    })
+
+    // ---- 区间边界数据：下界前一天与上界后一天都必须被排除 ----
+    await seedOutboundOrder({
+      createdAt: new Date(2025, 10, 30, 10, 0, 0),
+      orderType: 'walkin',
+      items: [{ productId: canvasBag.id, nameSnapshot: '帆布包', qty: 100, unitPrice: 20 }],
+    })
+    await seedOutboundOrder({
+      createdAt: new Date(2026, 8, 1, 10, 0, 0),
+      orderType: 'walkin',
+      items: [{ productId: canvasBag.id, nameSnapshot: '帆布包', qty: 200, unitPrice: 20 }],
+    })
+
+    // ---- 区间内数据：同一商品三种规格快照，分别落在首月首日、中间月、末月末日 ----
+    await seedOutboundOrder({
+      createdAt: new Date(2025, 11, 1, 9, 0, 0),
+      orderType: 'department',
+      departmentName: '行政部',
+      items: [{ productId: canvasBag.id, nameSnapshot: '帆布包', qty: 3, unitPrice: 20 }],
+    })
+    await seedOutboundOrder({
+      createdAt: new Date(2026, 2, 5, 1, 0, 0),
+      orderType: 'department',
+      departmentName: '行政部',
+      items: [{ productId: canvasBag.id, nameSnapshot: '帆布包（红色）', qty: 5, unitPrice: 20 }],
+    })
+    await seedOutboundOrder({
+      createdAt: new Date(2026, 7, 31, 23, 0, 0),
+      orderType: 'walkin',
+      items: [{ productId: canvasBag.id, nameSnapshot: '帆布包（蓝色）', qty: 7, unitPrice: 20 }],
+    })
+    await seedOutboundOrder({
+      createdAt: new Date(2026, 4, 20, 12, 0, 0),
+      orderType: 'department',
+      departmentName: '教务处',
+      items: [{ productId: mug.id, nameSnapshot: '马克杯', qty: 4, unitPrice: 30 }],
+    })
+
+    const baseRange = { startDate: RANGE_START, endDate: RANGE_END }
+
+    // ---- 1. 跨年区间边界 ----
+    const mergedAnalytics = await dashboardService.getAnalytics({ ...baseRange })
+    const mergedCanvas = mergedAnalytics.topProducts.find((item) => item.productId === canvasBag.id)
+    assert.ok(mergedCanvas, '合并模式应返回帆布包')
+    assert.equal(mergedCanvas.totalQty, '15.00', '合并数量必须只统计区间内的 3+5+7，不能含区间外的 100/200')
+    assert.equal(mergedCanvas.specLabel, null, '合并模式不应下发规格文本')
+    assert.equal(mergedCanvas.nameSnapshot, null, '合并模式不应下发名称快照')
+    assert.equal(mergedAnalytics.range.startDate, RANGE_START)
+    assert.equal(mergedAnalytics.range.endDate, RANGE_END)
+    assert.equal(mergedAnalytics.range.isDefault, false)
+    pass('跨年区间 2025-12-01 ~ 2026-08-31 准确覆盖首末月边界，且排除区间外单据')
+
+    // ---- 2. 合并 / 细分规格 ----
+    const specAnalytics = await dashboardService.getAnalytics({ ...baseRange, productSpecMode: 'spec' })
+    const specCanvasRows = specAnalytics.topProducts.filter((item) => item.productId === canvasBag.id)
+    assert.equal(specCanvasRows.length, 3, '细分模式下帆布包应按三种规格拆成三行')
+    const specLabels = specCanvasRows.map((item) => item.specLabel).sort()
+    assert.deepEqual(specLabels, ['默认规格', '红色', '蓝色'].sort(), '规格文本应从名称快照解析')
+    const specQtySum = specCanvasRows.reduce((sum, item) => sum + Number(item.totalQty), 0)
+    assert.equal(specQtySum.toFixed(2), mergedCanvas.totalQty, '同一区间内合并数量必须等于全部规格数量之和')
+    assert.equal(new Set(specCanvasRows.map((item) => item.rankKey)).size, 3, '细分模式各行 rankKey 必须唯一')
+    specCanvasRows.forEach((item) => {
+      assert.ok(item.nameSnapshot, '细分模式必须下发名称快照供下钻精确过滤')
+    })
+    pass('商品榜默认按商品合并，开启细分规格后可按款式区分且总量守恒')
+
+    // ---- 3. 先完整聚合再截断 Top N ----
+    for (let index = 0; index < 12; index += 1) {
+      const fillerProduct = await productService.create({
+        productName: `填充商品${index + 1}`,
+        defaultPrice: 5,
+        isActive: true,
+      })
+      await seedOutboundOrder({
+        createdAt: new Date(2026, 1, 10, 10, 0, 0),
+        orderType: 'walkin',
+        items: [{ productId: fillerProduct.id, nameSnapshot: `填充商品${index + 1}`, qty: 1, unitPrice: 5 }],
+      })
+    }
+
+    const topFive = await dashboardService.getAnalytics({ ...baseRange, topN: 5 })
+    assert.equal(topFive.topProducts.length, 5, '分组数超过 Top N 时应恰好返回 Top N 行')
+    assert.equal(topFive.topProducts[0]?.productId, canvasBag.id, '合并后数量最高的商品应排在第一')
+    assert.equal(topFive.topProducts[0]?.totalQty, '15.00', '榜首数量应为该商品全部规格之和，而不是被截断后的单一规格')
+    const topTwenty = await dashboardService.getAnalytics({ ...baseRange, topN: 20 })
+    assert.equal(topTwenty.topProducts.length, 14, 'Top 20 应返回区间内全部 14 个商品')
+    pass('Top N 截断发生在完整聚合之后，切换 5/10/20 均生效')
+
+    // ---- 4. 指定商品筛选与 Top N 兜底 ----
+    const singleProduct = await dashboardService.getAnalytics({
+      ...baseRange,
+      productId: canvasBag.id,
+      productSpecMode: 'spec',
+    })
+    assert.equal(singleProduct.topProducts.length, 3, '锁定单个商品后应只返回该商品的各规格')
+    assert.equal(
+      singleProduct.topProducts.every((item) => item.productId === canvasBag.id),
+      true,
+      '锁定单个商品后不应混入其他商品',
+    )
+    const clampedTopN = await dashboardService.getAnalytics({ ...baseRange, topN: 999 })
+    assert.equal(clampedTopN.range.topN, 5, '非法 Top N 应回落到默认值 5')
+    pass('支持锁定单个商品与规格模式组合，非法 Top N 会被兜底')
+
+    // ---- 5. 趋势分桶：按月连续补零 + 按日使用本地时区 ----
+    const monthlyTrend = await dashboardService.getAnalytics({ ...baseRange, granularity: 'month' })
+    assert.equal(monthlyTrend.trend.length, 9, '2025-12 至 2026-08 应产生 9 个月桶')
+    assert.equal(monthlyTrend.trend[0]?.date, '2025-12')
+    assert.equal(monthlyTrend.trend[8]?.date, '2026-08')
+    assert.equal(monthlyTrend.range.granularity, 'month')
+
+    const dailyTrend = await dashboardService.getAnalytics({
+      startDate: '2026-03-01',
+      endDate: '2026-03-31',
+      granularity: 'day',
+    })
+    assert.equal(dailyTrend.trend.length, 31, '三月按日应产生 31 个桶')
+    const march5Bucket = dailyTrend.trend.find((point) => point.date === '2026-03-05')
+    assert.ok(march5Bucket, '按日趋势应包含 2026-03-05')
+    assert.equal(march5Bucket.orderCount, 1, '凌晨 01:00 的单据必须落在本地日期当天，而不是被 UTC 转换算到前一天')
+    pass('趋势分桶按区间连续补零，且使用本地时区避免凌晨单据串日')
+
+    // ---- 6. 空区间与非法入参 ----
+    const emptyRange = await dashboardService.getAnalytics({ startDate: '2024-01-01', endDate: '2024-01-31' })
+    assert.deepEqual(emptyRange.topProducts, [], '空区间应返回空榜单而不是报错')
+    assert.deepEqual(emptyRange.topCustomers, [])
+    assert.equal(emptyRange.trend.length, 31, '空区间仍应返回补零后的完整桶')
+
+    await assert.rejects(
+      () => dashboardService.getAnalytics({ startDate: '2026-08-31', endDate: '2025-12-01' }),
+      /开始日期不能晚于结束日期/,
+    )
+    await assert.rejects(() => dashboardService.getAnalytics({ startDate: RANGE_START }), /需同时提供开始日期与结束日期/)
+    await assert.rejects(
+      () => dashboardService.getAnalytics({ startDate: '2025/12/01', endDate: RANGE_END }),
+      /格式不正确/,
+    )
+    await assert.rejects(
+      () => dashboardService.getAnalytics({ startDate: '2024-01-01', endDate: '2026-08-31' }),
+      /统计区间最长支持/,
+    )
+    await assert.rejects(
+      () => dashboardService.getAnalytics({ ...baseRange, orderType: 'unknown' }),
+      /orderType 非法/,
+    )
+    pass('空区间返回空榜单，非法起止时间与非法订单类型均有明确反馈')
+
+    // ---- 7. 饼图：商品维度合并 + “其他”补齐总额与占比 ----
+    const pieData = await dashboardService.getDashboardPieData({ ...baseRange })
+    const canvasSlices = pieData.productPie.filter((slice) => slice.key === canvasBag.id)
+    assert.equal(canvasSlices.length, 1, '商品占比必须按商品合并，同一商品不得因规格裂成多片')
+    assert.equal(canvasSlices[0]?.label, '帆布包', '合并后的分片应展示商品主名称而不是带规格的快照')
+    const otherSlice = pieData.productPie.find((slice) => slice.key === '__other__')
+    assert.ok(otherSlice, '分组数超过 8 时应补一片“其他”')
+
+    const pieValueSum = pieData.productPie.reduce((sum, slice) => sum + Number(slice.value), 0)
+    // 区间内金额：帆布包 15*20 + 马克杯 4*30 + 12 个填充商品各 1*5 = 300 + 120 + 60
+    assert.equal(pieValueSum.toFixed(2), '480.00', '各分片金额之和应等于区间真实总额')
+    const pieRatioSum = pieData.productPie.reduce((sum, slice) => sum + Number(slice.ratio), 0)
+    assert.ok(Math.abs(pieRatioSum - 100) <= 0.05, `各分片占比之和应约等于 100%，实际为 ${pieRatioSum.toFixed(2)}`)
+    assert.equal(pieData.range.startDate, RANGE_START)
+    assert.equal(pieData.range.endDate, RANGE_END)
+    pass('饼图按商品合并统计，“其他”分片保证总额与占比口径一致')
+
+    // ---- 8. 下钻继承区间与规格 ----
+    const specRow = specCanvasRows.find((item) => item.specLabel === '红色')
+    assert.ok(specRow?.nameSnapshot)
+    const specDrilldown = await dashboardService.getProductRankDrilldown({
+      productId: canvasBag.id,
+      nameSnapshot: specRow.nameSnapshot,
+      ...baseRange,
+    })
+    assert.equal(specDrilldown.totalQty, '5.00', '细分下钻应只统计该规格的数量')
+    const mergedDrilldown = await dashboardService.getProductRankDrilldown({
+      productId: canvasBag.id,
+      ...baseRange,
+    })
+    assert.equal(mergedDrilldown.totalQty, '15.00', '合并下钻应统计该商品全部规格，并受区间约束')
+    pass('下钻明细继承当前统计区间，并可按规格精确过滤')
+
+    // ---- 9. 概览接口瘦身回归 ----
+    const stats = await dashboardService.getStats()
+    assert.equal(typeof stats.todayOrderCount, 'number')
+    assert.equal(typeof stats.totalProductCount, 'number')
+    assert.equal(Array.isArray(stats.recentActivities), true)
+    assert.equal('topProducts' in stats, false, '区间相关榜单已迁移到 /dashboard/analytics，概览接口不应再返回')
+    assert.equal('trend7Days' in stats, false, '区间相关趋势已迁移到 /dashboard/analytics，概览接口不应再返回')
+    pass('概览接口只保留四宫格与近期动态，区间统计统一由分析接口提供')
+  } finally {
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy()
+    }
+  }
+}
+
+try {
+  await main()
+  console.log('\n首页区间分析自动化验证全部通过。')
+} catch (error) {
+  console.error('\n首页区间分析自动化验证失败：', error)
+  process.exit(1)
+}

--- a/backend/scripts/task345-verify.ts
+++ b/backend/scripts/task345-verify.ts
@@ -59,7 +59,14 @@ function verifyFrontendSources() {
   assert.match(orderEntrySource, /productApi\.createProduct\(\{/)
   assert.match(orderEntrySource, /productCode:\s*`Auto-\$\{globalThis\.crypto\.randomUUID\(\)\.slice\(0,\s*8\)\}`/)
 
-  assert.match(productManagerSource, /getProductDetail\(row\.id\)/)
+  // 编辑弹窗必须走详情接口回填，并且详情请求要透传 useStableRequest 下发的 signal：
+  // 少了 signal，连点不同行时旧详情会覆盖新选择（见 src/composables/useStableRequest.ts 的 runLatest）。
+  // 断言口径与 scripts/verify-enterprise-core-paths.mjs 中其他详情请求保持一致。
+  assert.match(
+    productManagerSource,
+    /executor: \(signal\) => getProductDetail\(row\.id, \{ signal \}\)/,
+    '产品编辑弹窗未走详情接口回填或未透传 signal',
+  )
   assert.match(productManagerSource, /batchUpdateProducts/)
   assert.match(productManagerSource, /留空则自动生成统一编码/)
   assert.match(productRouteSource, /productRouter\.post\(\s*'\/batch'/)

--- a/backend/src/routes/dashboard.routes.ts
+++ b/backend/src/routes/dashboard.routes.ts
@@ -1,5 +1,5 @@
 /**
- * 文件说明：看板统计路由，提供经营概览、商品钻取、客户钻取和标签聚合等后台分析接口。
+ * 文件说明：看板统计路由，提供经营概览、区间分析、商品钻取、客户钻取和标签聚合等后台分析接口。
  * 实现逻辑：路由层统一解析时间范围和筛选条件，再调用看板服务生成聚合结果，保证不同统计接口的过滤规则一致。
  * 维护重点：调整统计口径时，需要同步核对日期范围解析、订单类型筛选以及前端图表依赖的数据结构。
  */
@@ -23,6 +23,15 @@ const dashboardFilterQuerySchema = z.object({
 
 const productDrilldownQuerySchema = dashboardFilterQuerySchema.extend({
   productId: z.string().trim().min(1, 'productId 不能为空'),
+  // 细分规格模式下只看该规格对应的名称快照，合并模式不传该参数。
+  nameSnapshot: z.string().trim().min(1).optional(),
+})
+
+const analyticsQuerySchema = dashboardFilterQuerySchema.extend({
+  granularity: z.enum(['day', 'month']).optional(),
+  productSpecMode: z.enum(['merged', 'spec']).optional(),
+  productId: z.string().trim().min(1).optional(),
+  topN: z.coerce.number().int().optional(),
 })
 
 const customerDrilldownQuerySchema = dashboardFilterQuerySchema.extend({
@@ -81,6 +90,28 @@ dashboardRouter.get(
 )
 
 dashboardRouter.get(
+  '/analytics',
+  // 区间分析与看板统计同属经营指标，统一要求 dashboard:view。
+  requirePermission('dashboard:view'),
+  asyncHandler(async (req, res) => {
+    const query = analyticsQuerySchema.parse(req.query)
+    const filter = resolveDateRangeQuery(query)
+    const data = await dashboardService.getAnalytics({
+      ...filter,
+      granularity: query.granularity,
+      productSpecMode: query.productSpecMode,
+      productId: query.productId,
+      topN: query.topN,
+    })
+    res.json({
+      code: 0,
+      message: 'ok',
+      data,
+    })
+  }),
+)
+
+dashboardRouter.get(
   '/drilldown/products',
   // 商品下钻会暴露细粒度经营数据，统一纳入 dashboard:view。
   requirePermission('dashboard:view'),
@@ -89,6 +120,7 @@ dashboardRouter.get(
     const filter = resolveDateRangeQuery(query)
     const data = await dashboardService.getProductRankDrilldown({
       productId: query.productId,
+      nameSnapshot: query.nameSnapshot,
       ...filter,
     })
     res.json({

--- a/backend/src/services/dashboard.service.ts
+++ b/backend/src/services/dashboard.service.ts
@@ -303,29 +303,53 @@ const parseDateOnlyToStart = (value: string, label: string): Date => {
 /**
  * 解析规格展示文本：
  * - 出库明细表没有 SKU 外键，规格只存在于 productNameSnapshot 中；
- * - O2O 预订核销写入格式为“商品名（规格文本）”，因此优先剥离主商品名前缀再取全角括号内文本；
- * - 手工开单写入的是不含规格的商品名，统一归为“默认规格”。
+ * - O2O 预订核销写入格式为“商品名（规格文本）”，手工开单写入的是不含规格的商品名；
+ * - 解析分三级：主名称前缀匹配 → 快照末尾的全角括号 → 判定为无规格。
+ *
+ * 为什么不能只靠“剥离当前主商品名前缀”：
+ * - 商品改名后，主表是“新名称”，而历史明细快照仍是“旧名称（红色）”，前缀根本对不上；
+ * - 若此时直接把整段快照当规格返回，榜单会显示“新名称”后面挂一个旧的完整商品名标签，
+ *   而不是“红色”，跨区间做规格对比时会直接读错。
+ * - 因此前缀对不上时改从快照末尾独立解析括号内容，不依赖当前商品名。
+ *
+ * 已知无法消除的歧义：商品名本身自带尾部括号（例如“帆布包（限量版）”）且此后又改过名时，
+ * “限量版”会被当成规格。出库明细没有 SKU 字段，这种情况无从区分；要根治需要给
+ * biz_outbound_order_item 补 sku_id / spec_text_snapshot（见 issue #68）。
  */
 const resolveSpecLabel = (snapshot: string | null | undefined, masterName: string): string => {
   const normalizedSnapshot = normalizeText(snapshot, '')
   const normalizedMaster = normalizeText(masterName, '')
-  if (!normalizedSnapshot || normalizedSnapshot === normalizedMaster) {
+  if (!normalizedSnapshot) {
     return '默认规格'
   }
 
+  // 快照与当前主名称完全一致：说明没写规格后缀，且商品名自带的括号不能被误当成规格。
+  if (normalizedSnapshot === normalizedMaster) {
+    return '默认规格'
+  }
+
+  // 一级：商品未改名，剥掉主名称前缀后必须是一个完整的全角括号组才算规格，
+  // 否则像主名称“帆布”对快照“帆布包”这种前缀巧合，会把“包”误判成规格。
   if (normalizedMaster && normalizedSnapshot.startsWith(normalizedMaster)) {
     const remainder = normalizedSnapshot.slice(normalizedMaster.length).trim()
     if (!remainder) {
       return '默认规格'
     }
     const bracketMatched = /^（(.+)）$/.exec(remainder)
-    if (bracketMatched?.[1]) {
-      return bracketMatched[1].trim() || '默认规格'
+    if (bracketMatched?.[1]?.trim()) {
+      return bracketMatched[1].trim()
     }
-    return remainder
   }
 
-  return normalizedSnapshot
+  // 二级：商品已改名导致前缀对不上，从快照末尾的括号独立取规格。
+  const trailingMatched = /（([^（）]+)）\s*$/.exec(normalizedSnapshot)
+  if (trailingMatched?.[1]?.trim()) {
+    return trailingMatched[1].trim()
+  }
+
+  // 三级：既没有规格后缀，也和当前主名称对不上（多半是改名前的无规格历史单），
+  // 判定为无规格，而不是把旧商品名当成规格展示。
+  return '默认规格'
 }
 
 const resolveProductSpecMode = (value: string | undefined): DashboardProductSpecMode => {

--- a/backend/src/services/dashboard.service.ts
+++ b/backend/src/services/dashboard.service.ts
@@ -264,18 +264,6 @@ const normalizeRecentActivityDisplayName = (detail: Record<string, unknown>): st
   return customerName || '未填写客户'
 }
 
-const parseDateOnlyToStart = (value: string, label: string): Date => {
-  const normalized = value.trim()
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
-    throw new BizError(`${label}格式不正确，应为 YYYY-MM-DD`, 400)
-  }
-  const parsed = new Date(`${normalized}T00:00:00`)
-  if (Number.isNaN(parsed.getTime())) {
-    throw new BizError(`${label}格式不正确，应为 YYYY-MM-DD`, 400)
-  }
-  return parsed
-}
-
 /**
  * 本地日期键：
  * - 容器时区为 Asia/Shanghai，趋势分桶必须使用本地日期而不是 toISOString 的 UTC 日期；
@@ -292,6 +280,24 @@ const formatLocalMonthKey = (date: Date): string => {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
   return `${year}-${month}`
+}
+
+const parseDateOnlyToStart = (value: string, label: string): Date => {
+  const normalized = value.trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    throw new BizError(`${label}格式不正确，应为 YYYY-MM-DD`, 400)
+  }
+  const parsed = new Date(`${normalized}T00:00:00`)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BizError(`${label}格式不正确，应为 YYYY-MM-DD`, 400)
+  }
+  // JS 的 Date 只对“月份越界”返回 Invalid Date，对“日越界”会静默进位：
+  // 2026-02-31 会变成 2026-03-03、2026-04-31 会变成 2026-05-01。
+  // 若不回写比对，这类输入会悄悄查到错误区间，结束日越界时还会多算好几天。
+  if (formatLocalDateKey(parsed) !== normalized) {
+    throw new BizError(`${label}不是有效日期：${normalized}`, 400)
+  }
+  return parsed
 }
 
 /**

--- a/backend/src/services/dashboard.service.ts
+++ b/backend/src/services/dashboard.service.ts
@@ -1,10 +1,11 @@
 /**
  * 模块说明：`backend/src/services/dashboard.service.ts`
- * 文件职责：负责聚合管理端工作台所需的统计、排行、近期动态与下钻数据。
+ * 文件职责：负责聚合管理端工作台所需的统计、区间分析、排行、近期动态与下钻数据。
  * 实现逻辑：
- * 1. 统计指标直接从订单、明细、产品和审计日志聚合，并统一做金额/数量格式化；
- * 2. 近期动态补齐真实订单ID与展示名称，保持“部门优先、客户兜底”的口径一致；
- * 3. 排行、饼图和下钻共享筛选解析与兜底文案，降低前端判空分支复杂度。
+ * 1. 四宫格与近期动态维持“今日/本月”固定口径，区间相关的趋势与排行统一由 getAnalytics 提供；
+ * 2. 区间过滤、订单类型过滤、软删除排除全部收敛到 applyOrderFilter，保证各接口口径一致；
+ * 3. 商品排行支持“按商品合并 / 按规格细分”两种维度，聚合在 SQL 内先完成再截断 Top N；
+ * 4. 时间分桶一律在服务层完成，不使用任何数据库方言日期函数，保证 SQLite 与 MySQL 行为一致。
  */
 
 import { AppDataSource } from '../config/data-source.js'
@@ -15,6 +16,7 @@ import { BaseProduct } from '../entities/base-product.entity.js'
 import { RelProductTag } from '../entities/rel-product-tag.entity.js'
 import { SysAuditLog } from '../entities/sys-audit-log.entity.js'
 import type {
+  DashboardAmountSumRaw,
   DashboardCustomerDetailRaw,
   DashboardCustomerSummaryRaw,
   DashboardNumericLike,
@@ -23,7 +25,10 @@ import type {
   DashboardPieOrderTypeRowRaw,
   DashboardPieProductRowRaw,
   DashboardProductDetailRaw,
+  DashboardRankCustomerRowRaw,
+  DashboardRankProductRowRaw,
   DashboardTagAggregateRaw,
+  DashboardTrendOrderRowRaw,
 } from '../types/dashboard.js'
 import { BizError } from '../utils/errors.js'
 
@@ -36,8 +41,12 @@ interface DashboardTrendPoint {
 }
 
 interface DashboardTopProduct {
+  rankKey: string
   productId: string
   productName: string
+  specLabel: string | null
+  /** 细分模式下该行对应的出库明细名称快照，供下钻精确过滤；合并模式为 null。 */
+  nameSnapshot: string | null
   totalQty: string
 }
 
@@ -55,9 +64,6 @@ interface DashboardStatsResult {
   totalProductCount: number
   monthOrderCount: number
   monthOrderAmount: string | number
-  trend7Days: DashboardTrendPoint[]
-  topProducts: DashboardTopProduct[]
-  topCustomers: DashboardTopCustomer[]
   recentActivities: DashboardRecentActivity[]
 }
 
@@ -79,16 +85,61 @@ const DATE_MS = 24 * 60 * 60 * 1000
 const ORDER_TYPE_VALUES = ['department', 'walkin'] as const
 type DashboardOrderType = (typeof ORDER_TYPE_VALUES)[number]
 
+// 区间上限：统计区间最长一年，既覆盖“年末/学期报告”场景，也避免趋势分桶扫描无界行数。
+const MAX_RANGE_DAYS = 366
+// 超过该天数时趋势默认切换为按月分桶，避免跨年区间画出数百个日点。
+const TREND_DAY_BUCKET_MAX_DAYS = 62
+// 榜单可选条数，与前端下拉保持一致；非法值一律回落到 5。
+const RANK_TOP_N_VALUES = [5, 10, 20] as const
+// 饼图最多展示的分片数，超出部分统一并入“其他”。
+const PIE_TOP_LIMIT = 8
+const PIE_OTHER_SLICE_KEY = '__other__'
+const PIE_OTHER_SLICE_LABEL = '其他'
+// 金额/数量归一化后保留两位小数，判定“是否还有其他分片”时用半个最小单位做容差。
+const PIE_OTHER_EPSILON = 0.005
+
+const PRODUCT_SPEC_MODES = ['merged', 'spec'] as const
+type DashboardProductSpecMode = (typeof PRODUCT_SPEC_MODES)[number]
+
+const TREND_GRANULARITIES = ['day', 'month'] as const
+type DashboardTrendGranularity = (typeof TREND_GRANULARITIES)[number]
+
 interface DashboardFilterInput {
   startDate?: string
   endDate?: string
   orderType?: string
 }
 
+interface DashboardAnalyticsInput extends DashboardFilterInput {
+  granularity?: string
+  productSpecMode?: string
+  productId?: string
+  topN?: number | string
+}
+
 interface DashboardResolvedFilter {
   startAt?: Date
   endExclusive?: Date
   orderType?: DashboardOrderType
+  startDate: string
+  endDate: string
+  isDefaultRange: boolean
+}
+
+interface DashboardAnalyticsResult {
+  range: {
+    startDate: string
+    endDate: string
+    granularity: DashboardTrendGranularity
+    orderType: DashboardOrderType | null
+    productSpecMode: DashboardProductSpecMode
+    productId: string | null
+    topN: number
+    isDefault: boolean
+  }
+  trend: DashboardTrendPoint[]
+  topProducts: DashboardTopProduct[]
+  topCustomers: DashboardTopCustomer[]
 }
 
 interface DashboardDrilldownOrderRecord {
@@ -140,6 +191,12 @@ interface DashboardPiePayload {
   productPie: DashboardPieSlice[]
   customerPie: DashboardPieSlice[]
   orderTypePie: DashboardPieSlice[]
+  range: {
+    startDate: string
+    endDate: string
+    orderType: DashboardOrderType | null
+    isDefault: boolean
+  }
 }
 
 /**
@@ -219,23 +276,83 @@ const parseDateOnlyToStart = (value: string, label: string): Date => {
   return parsed
 }
 
-const resolveDashboardFilter = (input: DashboardFilterInput): DashboardResolvedFilter => {
+/**
+ * 本地日期键：
+ * - 容器时区为 Asia/Shanghai，趋势分桶必须使用本地日期而不是 toISOString 的 UTC 日期；
+ * - 否则每天 00:00-08:00 的单据会被算进前一天，跨月跨年区间下该偏差会被放大。
+ */
+const formatLocalDateKey = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const formatLocalMonthKey = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  return `${year}-${month}`
+}
+
+/**
+ * 解析规格展示文本：
+ * - 出库明细表没有 SKU 外键，规格只存在于 productNameSnapshot 中；
+ * - O2O 预订核销写入格式为“商品名（规格文本）”，因此优先剥离主商品名前缀再取全角括号内文本；
+ * - 手工开单写入的是不含规格的商品名，统一归为“默认规格”。
+ */
+const resolveSpecLabel = (snapshot: string | null | undefined, masterName: string): string => {
+  const normalizedSnapshot = normalizeText(snapshot, '')
+  const normalizedMaster = normalizeText(masterName, '')
+  if (!normalizedSnapshot || normalizedSnapshot === normalizedMaster) {
+    return '默认规格'
+  }
+
+  if (normalizedMaster && normalizedSnapshot.startsWith(normalizedMaster)) {
+    const remainder = normalizedSnapshot.slice(normalizedMaster.length).trim()
+    if (!remainder) {
+      return '默认规格'
+    }
+    const bracketMatched = /^（(.+)）$/.exec(remainder)
+    if (bracketMatched?.[1]) {
+      return bracketMatched[1].trim() || '默认规格'
+    }
+    return remainder
+  }
+
+  return normalizedSnapshot
+}
+
+const resolveProductSpecMode = (value: string | undefined): DashboardProductSpecMode => {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  return PRODUCT_SPEC_MODES.includes(normalized as DashboardProductSpecMode)
+    ? (normalized as DashboardProductSpecMode)
+    : 'merged'
+}
+
+const resolveTopN = (value: number | string | undefined): number => {
+  const normalized = Number(value ?? RANK_TOP_N_VALUES[0])
+  if (!Number.isFinite(normalized)) {
+    return RANK_TOP_N_VALUES[0]
+  }
+  const matched = RANK_TOP_N_VALUES.find((candidate) => candidate === Math.trunc(normalized))
+  return matched ?? RANK_TOP_N_VALUES[0]
+}
+
+/**
+ * 解析看板筛选条件：
+ * - defaultRange 为 currentMonth 时，未传区间回落到“本月 1 日至今日”，让首页各卡片默认口径一致；
+ * - defaultRange 为 all 时保持历史行为（未传区间即全量），供标签聚合等旧调用方继续使用；
+ * - 区间统一左闭右开（>= 起始日 00:00，< 结束日次日 00:00），因此结束日整天都会被覆盖。
+ */
+const resolveDashboardFilter = (
+  input: DashboardFilterInput,
+  options: { defaultRange?: 'all' | 'currentMonth' } = {},
+): DashboardResolvedFilter => {
   const normalizedStartDate = typeof input.startDate === 'string' ? input.startDate.trim() : ''
   const normalizedEndDate = typeof input.endDate === 'string' ? input.endDate.trim() : ''
 
   if ((normalizedStartDate && !normalizedEndDate) || (!normalizedStartDate && normalizedEndDate)) {
     throw new BizError('dateRange 需同时提供开始日期与结束日期', 400)
-  }
-
-  let startAt: Date | undefined
-  let endExclusive: Date | undefined
-  if (normalizedStartDate && normalizedEndDate) {
-    startAt = parseDateOnlyToStart(normalizedStartDate, '开始日期')
-    const endAt = parseDateOnlyToStart(normalizedEndDate, '结束日期')
-    if (startAt.getTime() > endAt.getTime()) {
-      throw new BizError('dateRange 不合法：开始日期不能晚于结束日期', 400)
-    }
-    endExclusive = new Date(endAt.getTime() + DATE_MS)
   }
 
   let orderType: DashboardOrderType | undefined
@@ -247,11 +364,69 @@ const resolveDashboardFilter = (input: DashboardFilterInput): DashboardResolvedF
     orderType = normalizedOrderType as DashboardOrderType
   }
 
+  if (!normalizedStartDate && !normalizedEndDate) {
+    if (options.defaultRange !== 'currentMonth') {
+      return {
+        startAt: undefined,
+        endExclusive: undefined,
+        orderType,
+        startDate: '',
+        endDate: '',
+        isDefaultRange: true,
+      }
+    }
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1)
+    return {
+      startAt: monthStart,
+      endExclusive: new Date(today.getTime() + DATE_MS),
+      orderType,
+      startDate: formatLocalDateKey(monthStart),
+      endDate: formatLocalDateKey(today),
+      isDefaultRange: true,
+    }
+  }
+
+  const startAt = parseDateOnlyToStart(normalizedStartDate, '开始日期')
+  const endAt = parseDateOnlyToStart(normalizedEndDate, '结束日期')
+  if (startAt.getTime() > endAt.getTime()) {
+    throw new BizError('dateRange 不合法：开始日期不能晚于结束日期', 400)
+  }
+
+  const spanDays = Math.round((endAt.getTime() - startAt.getTime()) / DATE_MS) + 1
+  if (spanDays > MAX_RANGE_DAYS) {
+    throw new BizError(`统计区间最长支持 ${MAX_RANGE_DAYS} 天，请缩小查询范围`, 400)
+  }
+
   return {
     startAt,
-    endExclusive,
+    endExclusive: new Date(endAt.getTime() + DATE_MS),
     orderType,
+    startDate: formatLocalDateKey(startAt),
+    endDate: formatLocalDateKey(endAt),
+    isDefaultRange: false,
   }
+}
+
+/**
+ * 解析趋势分桶粒度：
+ * - 显式传入时以调用方为准，用于“按月筛选就按月看趋势”的场景；
+ * - 未传入时按区间长度自适应，避免跨年区间在折线图上堆出数百个日点。
+ */
+const resolveTrendGranularity = (
+  value: string | undefined,
+  startAt: Date,
+  endExclusive: Date,
+): DashboardTrendGranularity => {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  if (TREND_GRANULARITIES.includes(normalized as DashboardTrendGranularity)) {
+    return normalized as DashboardTrendGranularity
+  }
+
+  const spanDays = Math.round((endExclusive.getTime() - startAt.getTime()) / DATE_MS)
+  return spanDays > TREND_DAY_BUCKET_MAX_DAYS ? 'month' : 'day'
 }
 
 /**
@@ -278,10 +453,8 @@ export const dashboardService = {
     today.setHours(0, 0, 0, 0)
 
     const monthStart = new Date(today.getFullYear(), today.getMonth(), 1)
-    const trendStart = new Date(today.getTime() - 6 * DATE_MS)
 
     const orderRepo = AppDataSource.getRepository(BizOutboundOrder)
-    const orderItemRepo = AppDataSource.getRepository(BizOutboundOrderItem)
     const productRepo = AppDataSource.getRepository(BaseProduct)
     const auditLogRepo = AppDataSource.getRepository(SysAuditLog)
 
@@ -291,7 +464,7 @@ export const dashboardService = {
       monthOrderCount,
       monthOrderAmountResult,
       totalProductCount,
-      recentOrders,
+      recentAuditLogs,
     ] = await Promise.all([
       // 今日单数（软删除单据不计入看板）。
       orderRepo
@@ -324,81 +497,6 @@ export const dashboardService = {
         .createQueryBuilder('product')
         .where('product.isActive = :isActive', { isActive: true })
         .getCount(),
-      // 近 7 日趋势：先查最近 7 天有效订单，再在服务层按日聚合，避免数据库方言差异。
-      orderRepo
-        .createQueryBuilder('order')
-        .select(['order.createdAt AS createdAt', 'order.totalAmount AS totalAmount', 'order.totalQty AS totalQty'])
-        .where('order.createdAt >= :trendStart', { trendStart })
-        .andWhere('order.isDeleted = :isDeleted', { isDeleted: false })
-        .orderBy('order.createdAt', 'ASC')
-        .getRawMany<{ createdAt: Date | string; totalAmount: string | number; totalQty: string | number }>(),
-    ])
-    const todayOrderAmountRaw = todayOrderAmountResult?.totalAmount
-    const monthOrderAmountRaw = monthOrderAmountResult?.totalAmount
-
-    const trendMetricsMap = new Map<string, { amount: number; orderCount: number; totalQty: number }>()
-    recentOrders.forEach((order) => {
-      const createdAtDate = order.createdAt instanceof Date ? order.createdAt : new Date(order.createdAt)
-      if (Number.isNaN(createdAtDate.getTime())) {
-        return
-      }
-      const dateKey = createdAtDate.toISOString().slice(0, 10)
-      const currentMetrics = trendMetricsMap.get(dateKey) ?? {
-        amount: 0,
-        orderCount: 0,
-        totalQty: 0,
-      }
-      currentMetrics.amount += Number(order.totalAmount ?? 0)
-      currentMetrics.orderCount += 1
-      currentMetrics.totalQty += Number(order.totalQty ?? 0)
-      trendMetricsMap.set(dateKey, currentMetrics)
-    })
-
-    const trend7Days: DashboardTrendPoint[] = []
-    for (let index = 0; index < 7; index += 1) {
-      const currentDate = new Date(trendStart.getTime() + index * DATE_MS)
-      const dateKey = currentDate.toISOString().slice(0, 10)
-      const currentMetrics = trendMetricsMap.get(dateKey) ?? {
-        amount: 0,
-        orderCount: 0,
-        totalQty: 0,
-      }
-      trend7Days.push({
-        date: dateKey,
-        label: dateKey.slice(5).replace('-', '/'),
-        amount: normalizeAmount(currentMetrics.amount),
-        orderCount: currentMetrics.orderCount,
-        totalQty: normalizeQty(currentMetrics.totalQty),
-      })
-    }
-
-    const customerLabelExpr = `COALESCE(NULLIF(TRIM(order.customerDepartmentName), ''), '散客')`
-    const [topProductsRaw, topCustomersRaw, recentAuditLogs] = await Promise.all([
-      // 热门文创榜：统计本月有效出库的产品数量 Top5。
-      orderItemRepo
-        .createQueryBuilder('item')
-        .innerJoin(BizOutboundOrder, 'order', 'order.id = item.orderId')
-        .select('item.productId', 'productId')
-        .addSelect('item.productNameSnapshot', 'productName')
-        .addSelect('SUM(item.qty)', 'totalQty')
-        .where('order.createdAt >= :monthStart', { monthStart })
-        .andWhere('order.isDeleted = :isDeleted', { isDeleted: false })
-        .groupBy('item.productId')
-        .addGroupBy('item.productNameSnapshot')
-        .orderBy('SUM(item.qty)', 'DESC')
-        .limit(5)
-        .getRawMany<{ productId: string; productName: string; totalQty: string | number }>(),
-      orderRepo
-        .createQueryBuilder('order')
-        .select(customerLabelExpr, 'customerName')
-        .addSelect('SUM(order.totalAmount)', 'totalAmount')
-        .addSelect('COUNT(order.id)', 'orderCount')
-        .where('order.createdAt >= :monthStart', { monthStart })
-        .andWhere('order.isDeleted = :isDeleted', { isDeleted: false })
-        .groupBy(customerLabelExpr)
-        .orderBy('SUM(order.totalAmount)', 'DESC')
-        .limit(5)
-        .getRawMany<{ customerName: string | null; totalAmount: string | number; orderCount: string | number }>(),
       // 近期出库动态：聚合最近 10 条“新建/删除/恢复”事件，供首页时间流展示。
       auditLogRepo
         .createQueryBuilder('audit')
@@ -409,18 +507,8 @@ export const dashboardService = {
         .limit(10)
         .getMany(),
     ])
-
-    const topProducts: DashboardTopProduct[] = topProductsRaw.map((item) => ({
-      productId: String(item.productId ?? '').trim(),
-      productName: String(item.productName ?? '').trim() || '未命名文创',
-      totalQty: normalizeQty(item.totalQty),
-    }))
-
-    const topCustomers: DashboardTopCustomer[] = topCustomersRaw.map((item) => ({
-      customerName: normalizeText(item.customerName, '散客'),
-      totalAmount: normalizeAmount(item.totalAmount),
-      orderCount: Number(item.orderCount ?? 0),
-    }))
+    const todayOrderAmountRaw = todayOrderAmountResult?.totalAmount
+    const monthOrderAmountRaw = monthOrderAmountResult?.totalAmount
 
     const recentActivities: DashboardRecentActivity[] = recentAuditLogs.map((audit) => {
       const detail = parseAuditDetail(audit.detailJson)
@@ -450,21 +538,136 @@ export const dashboardService = {
       totalProductCount,
       monthOrderCount,
       monthOrderAmount: normalizeAmount(monthOrderAmountRaw),
-      trend7Days,
-      topProducts,
-      topCustomers,
       recentActivities,
     }
   },
 
+  /**
+   * 区间分析：
+   * - 首页“结构占比”筛选栏统一驱动趋势图、热门商品榜与部门榜；
+   * - 商品榜默认按商品合并，可切换为按规格细分，并支持锁定单个商品做款式横向比较；
+   * - Top N 截断发生在 SQL 聚合之后，因此合并数量恒等于该商品全部规格数量之和。
+   */
+  async getAnalytics(input: DashboardAnalyticsInput): Promise<DashboardAnalyticsResult> {
+    const filter = resolveDashboardFilter(input, { defaultRange: 'currentMonth' })
+    if (!filter.startAt || !filter.endExclusive) {
+      throw new BizError('统计区间解析失败，请重新选择起止日期', 400)
+    }
+
+    const granularity = resolveTrendGranularity(input.granularity, filter.startAt, filter.endExclusive)
+    const productSpecMode = resolveProductSpecMode(input.productSpecMode)
+    const topN = resolveTopN(input.topN)
+    const productId = normalizeText(input.productId, '')
+
+    const orderRepo = AppDataSource.getRepository(BizOutboundOrder)
+    const orderItemRepo = AppDataSource.getRepository(BizOutboundOrderItem)
+
+    // 趋势原始行：只取分桶必需的列，日期分桶放到服务层，避免引入方言日期函数。
+    // 必须走 getMany 的实体水合而不是 getRawMany：原始结果会跳过驱动的时间归一化，
+    // SQLite 会返回不带时区标记的 UTC 字符串，再被 new Date() 当成本地时间解析，导致整段趋势串日。
+    // 主键一并选出，否则 TypeORM 无法区分实体行，会把同一分钟的多张单据折叠成一条。
+    const trendRowsQb = orderRepo
+      .createQueryBuilder('order')
+      .select(['order.id', 'order.createdAt', 'order.totalAmount', 'order.totalQty'])
+      .where('1=1')
+      .orderBy('order.createdAt', 'ASC')
+    this.applyOrderFilter(trendRowsQb, filter)
+
+    // 商品榜：合并模式只按商品分组，细分模式追加名称快照分组以区分规格。
+    const productRankQb = orderItemRepo
+      .createQueryBuilder('item')
+      .innerJoin(BizOutboundOrder, 'order', 'order.id = item.orderId')
+      .leftJoin(BaseProduct, 'product', 'product.id = item.productId')
+      .select('item.productId', 'productId')
+      .addSelect('MAX(product.productName)', 'masterName')
+      .addSelect('SUM(item.qty)', 'totalQty')
+      .where('1=1')
+      .groupBy('item.productId')
+      .orderBy('SUM(item.qty)', 'DESC')
+      .addOrderBy('item.productId', 'ASC')
+      .limit(topN)
+    if (productSpecMode === 'spec') {
+      productRankQb
+        .addSelect('item.productNameSnapshot', 'snapshotName')
+        .addGroupBy('item.productNameSnapshot')
+        .addOrderBy('item.productNameSnapshot', 'ASC')
+    } else {
+      // MySQL 8 默认开启 ONLY_FULL_GROUP_BY，非分组列必须包在聚合函数里。
+      productRankQb.addSelect('MAX(item.productNameSnapshot)', 'snapshotName')
+    }
+    if (productId) {
+      productRankQb.andWhere('item.productId = :rankProductId', { rankProductId: productId })
+    }
+    this.applyOrderFilter(productRankQb, filter)
+
+    const customerLabelExpr = `COALESCE(NULLIF(TRIM(order.customerDepartmentName), ''), '散客')`
+    const customerRankQb = orderRepo
+      .createQueryBuilder('order')
+      .select(customerLabelExpr, 'customerName')
+      .addSelect('SUM(order.totalAmount)', 'totalAmount')
+      .addSelect('COUNT(order.id)', 'orderCount')
+      .where('1=1')
+      .groupBy(customerLabelExpr)
+      .orderBy('SUM(order.totalAmount)', 'DESC')
+      .addOrderBy(customerLabelExpr, 'ASC')
+      .limit(topN)
+    this.applyOrderFilter(customerRankQb, filter)
+
+    const [trendRows, productRankRows, customerRankRows] = await Promise.all([
+      trendRowsQb.getMany(),
+      productRankQb.getRawMany<DashboardRankProductRowRaw>(),
+      customerRankQb.getRawMany<DashboardRankCustomerRowRaw>(),
+    ])
+
+    const trend = this.buildTrendPoints(trendRows, filter.startAt, filter.endExclusive, granularity)
+
+    const topProducts: DashboardTopProduct[] = productRankRows.map((row) => {
+      const normalizedProductId = String(row.productId ?? '').trim()
+      const snapshotName = normalizeText(row.snapshotName, '')
+      const productName = normalizeText(row.masterName, '') || snapshotName || '未命名文创'
+      const specLabel = productSpecMode === 'spec' ? resolveSpecLabel(snapshotName, productName) : null
+      return {
+        rankKey: productSpecMode === 'spec' ? `${normalizedProductId}::${snapshotName}` : normalizedProductId,
+        productId: normalizedProductId,
+        productName,
+        specLabel,
+        nameSnapshot: productSpecMode === 'spec' ? snapshotName : null,
+        totalQty: normalizeQty(row.totalQty),
+      }
+    })
+
+    const topCustomers: DashboardTopCustomer[] = customerRankRows.map((row) => ({
+      customerName: normalizeText(row.customerName, '散客'),
+      totalAmount: normalizeAmount(row.totalAmount),
+      orderCount: Number(row.orderCount ?? 0),
+    }))
+
+    return {
+      range: {
+        startDate: filter.startDate,
+        endDate: filter.endDate,
+        granularity,
+        orderType: filter.orderType ?? null,
+        productSpecMode,
+        productId: productId || null,
+        topN,
+        isDefault: filter.isDefaultRange,
+      },
+      trend,
+      topProducts,
+      topCustomers,
+    }
+  },
+
   async getProductRankDrilldown(
-    input: { productId: string } & DashboardFilterInput,
+    input: { productId: string; nameSnapshot?: string } & DashboardFilterInput,
   ): Promise<DashboardProductRankDrilldownResult> {
     const productId = String(input.productId ?? '').trim()
     if (!productId) {
       throw new BizError('productId 不能为空', 400)
     }
 
+    const nameSnapshot = normalizeText(input.nameSnapshot, '')
     const filter = resolveDashboardFilter(input)
     const orderItemRepo = AppDataSource.getRepository(BizOutboundOrderItem)
     const productRepo = AppDataSource.getRepository(BaseProduct)
@@ -478,6 +681,7 @@ export const dashboardService = {
       .addSelect('MAX(item.productNameSnapshot)', 'productName')
       .where('item.productId = :productId', { productId })
 
+    this.applyProductSnapshotFilter(summaryQb, nameSnapshot)
     this.applyOrderFilter(summaryQb, filter)
     type DashboardProductSummaryRaw = {
       totalQty?: DashboardNumericLike
@@ -510,6 +714,7 @@ export const dashboardService = {
       .orderBy('order.createdAt', 'DESC')
       .limit(100)
 
+    this.applyProductSnapshotFilter(detailQb, nameSnapshot)
     this.applyOrderFilter(detailQb, filter)
     const detailRows = await detailQb.getRawMany<DashboardProductDetailRaw>()
 
@@ -617,31 +822,37 @@ export const dashboardService = {
     }
   },
 
+  /**
+   * 结构占比饼图：
+   * - 商品维度只按商品合并，同一商品的不同规格不再裂成多片；
+   * - 分片截断到 Top 8 后补一片“其他”，保证卡片总额等于区间真实总额、占比之和为 100%。
+   */
   async getDashboardPieData(input: DashboardFilterInput): Promise<DashboardPiePayload> {
-    const filter = resolveDashboardFilter(input)
+    const filter = resolveDashboardFilter(input, { defaultRange: 'currentMonth' })
     const orderRepo = AppDataSource.getRepository(BizOutboundOrder)
     const itemRepo = AppDataSource.getRepository(BizOutboundOrderItem)
 
     const productRowsQb = itemRepo
       .createQueryBuilder('item')
       .innerJoin(BizOutboundOrder, 'order', 'order.id = item.orderId')
+      .leftJoin(BaseProduct, 'product', 'product.id = item.productId')
       .select('item.productId', 'key')
-      .addSelect('item.productNameSnapshot', 'label')
+      .addSelect('MAX(product.productName)', 'masterLabel')
+      .addSelect('MAX(item.productNameSnapshot)', 'label')
       .addSelect('SUM(item.lineAmount)', 'value')
       .where('1=1')
       .groupBy('item.productId')
-      .addGroupBy('item.productNameSnapshot')
       .orderBy('SUM(item.lineAmount)', 'DESC')
-      .limit(8)
+      .addOrderBy('item.productId', 'ASC')
+      .limit(PIE_TOP_LIMIT)
     this.applyOrderFilter(productRowsQb, filter)
-    const productRows = await productRowsQb.getRawMany<DashboardPieProductRowRaw>()
-    const productPie = this.buildPieSlices(
-      productRows.map((row) => ({
-        key: String(row.key ?? '').trim(),
-        label: normalizeText(row.label, '未命名文创'),
-        value: Number(row.value ?? 0),
-      })),
-    )
+
+    const productTotalQb = itemRepo
+      .createQueryBuilder('item')
+      .innerJoin(BizOutboundOrder, 'order', 'order.id = item.orderId')
+      .select('SUM(item.lineAmount)', 'totalValue')
+      .where('1=1')
+    this.applyOrderFilter(productTotalQb, filter)
 
     const customerLabelExpr = `COALESCE(NULLIF(TRIM(order.customerDepartmentName), ''), '散客')`
     const customerRowsQb = orderRepo
@@ -652,16 +863,15 @@ export const dashboardService = {
       .where('1=1')
       .groupBy(customerLabelExpr)
       .orderBy('SUM(order.totalAmount)', 'DESC')
-      .limit(8)
+      .addOrderBy(customerLabelExpr, 'ASC')
+      .limit(PIE_TOP_LIMIT)
     this.applyOrderFilter(customerRowsQb, filter)
-    const customerRows = await customerRowsQb.getRawMany<DashboardPieCustomerRowRaw>()
-    const customerPie = this.buildPieSlices(
-      customerRows.map((row) => ({
-        key: normalizeText(row.key, '散客'),
-        label: normalizeText(row.label, '散客'),
-        value: Number(row.value ?? 0),
-      })),
-    )
+
+    const customerTotalQb = orderRepo
+      .createQueryBuilder('order')
+      .select('SUM(order.totalAmount)', 'totalValue')
+      .where('1=1')
+    this.applyOrderFilter(customerTotalQb, filter)
 
     const orderTypeRowsQb = orderRepo
       .createQueryBuilder('order')
@@ -670,7 +880,33 @@ export const dashboardService = {
       .where('1=1')
       .groupBy('order.orderType')
     this.applyOrderFilter(orderTypeRowsQb, filter)
-    const orderTypeRows = await orderTypeRowsQb.getRawMany<DashboardPieOrderTypeRowRaw>()
+
+    const [productRows, productTotalRaw, customerRows, customerTotalRaw, orderTypeRows] = await Promise.all([
+      productRowsQb.getRawMany<DashboardPieProductRowRaw>(),
+      productTotalQb.getRawOne<DashboardAmountSumRaw>(),
+      customerRowsQb.getRawMany<DashboardPieCustomerRowRaw>(),
+      customerTotalQb.getRawOne<DashboardAmountSumRaw>(),
+      orderTypeRowsQb.getRawMany<DashboardPieOrderTypeRowRaw>(),
+    ])
+
+    const productPie = this.buildPieSlices(
+      productRows.map((row) => ({
+        key: String(row.key ?? '').trim(),
+        label: normalizeText(row.masterLabel, '') || normalizeText(row.label, '未命名文创'),
+        value: Number(row.value ?? 0),
+      })),
+      { totalValue: Number(productTotalRaw?.totalValue ?? 0) },
+    )
+
+    const customerPie = this.buildPieSlices(
+      customerRows.map((row) => ({
+        key: normalizeText(row.key, '散客'),
+        label: normalizeText(row.label, '散客'),
+        value: Number(row.value ?? 0),
+      })),
+      { totalValue: Number(customerTotalRaw?.totalValue ?? 0) },
+    )
+
     const orderTypeMap = new Map<DashboardOrderType, number>()
     ORDER_TYPE_VALUES.forEach((orderType) => {
       orderTypeMap.set(orderType, 0)
@@ -688,13 +924,19 @@ export const dashboardService = {
         label: normalizeOrderTypeLabel(orderType),
         value: orderTypeMap.get(orderType) ?? 0,
       })),
-      normalizeCount,
+      { normalizeValue: normalizeCount },
     )
 
     return {
       productPie,
       customerPie,
       orderTypePie,
+      range: {
+        startDate: filter.startDate,
+        endDate: filter.endDate,
+        orderType: filter.orderType ?? null,
+        isDefault: filter.isDefaultRange,
+      },
     }
   },
 
@@ -713,6 +955,77 @@ export const dashboardService = {
 
   applyCustomerFilter(queryBuilder: { andWhere: (sql: string, parameters?: Record<string, unknown>) => unknown }, customerName: string): void {
     queryBuilder.andWhere(`COALESCE(NULLIF(TRIM(order.customerDepartmentName), ''), '散客') = :customerName`, { customerName })
+  },
+
+  /**
+   * 规格下钻过滤：
+   * - 细分规格模式下点击榜单项时，只看该规格对应的名称快照；
+   * - 合并模式不传该参数，保持商品维度的全量下钻。
+   */
+  applyProductSnapshotFilter(
+    queryBuilder: { andWhere: (sql: string, parameters?: Record<string, unknown>) => unknown },
+    nameSnapshot: string,
+  ): void {
+    if (!nameSnapshot) {
+      return
+    }
+    queryBuilder.andWhere('item.productNameSnapshot = :nameSnapshot', { nameSnapshot })
+  },
+
+  /**
+   * 趋势分桶：
+   * - 桶键使用本地日期/月份，避免 toISOString 的 UTC 日期在 +08 时区把凌晨单据算到前一天；
+   * - 区间内没有单据的桶补零，保证折线连续且横轴覆盖完整所选区间。
+   */
+  buildTrendPoints(
+    rows: DashboardTrendOrderRowRaw[],
+    startAt: Date,
+    endExclusive: Date,
+    granularity: DashboardTrendGranularity,
+  ): DashboardTrendPoint[] {
+    const metricsMap = new Map<string, { amount: number; orderCount: number; totalQty: number }>()
+    rows.forEach((row) => {
+      const createdAtDate = row.createdAt instanceof Date ? row.createdAt : new Date(row.createdAt)
+      if (Number.isNaN(createdAtDate.getTime())) {
+        return
+      }
+      const bucketKey = granularity === 'month' ? formatLocalMonthKey(createdAtDate) : formatLocalDateKey(createdAtDate)
+      const currentMetrics = metricsMap.get(bucketKey) ?? { amount: 0, orderCount: 0, totalQty: 0 }
+      currentMetrics.amount += Number(row.totalAmount ?? 0)
+      currentMetrics.orderCount += 1
+      currentMetrics.totalQty += Number(row.totalQty ?? 0)
+      metricsMap.set(bucketKey, currentMetrics)
+    })
+
+    const points: DashboardTrendPoint[] = []
+    const appendPoint = (bucketKey: string, label: string) => {
+      const currentMetrics = metricsMap.get(bucketKey) ?? { amount: 0, orderCount: 0, totalQty: 0 }
+      points.push({
+        date: bucketKey,
+        label,
+        amount: normalizeAmount(currentMetrics.amount),
+        orderCount: currentMetrics.orderCount,
+        totalQty: normalizeQty(currentMetrics.totalQty),
+      })
+    }
+
+    if (granularity === 'month') {
+      let monthCursor = new Date(startAt.getFullYear(), startAt.getMonth(), 1)
+      while (monthCursor.getTime() < endExclusive.getTime()) {
+        const bucketKey = formatLocalMonthKey(monthCursor)
+        appendPoint(bucketKey, bucketKey.replace('-', '/'))
+        monthCursor = new Date(monthCursor.getFullYear(), monthCursor.getMonth() + 1, 1)
+      }
+      return points
+    }
+
+    let dayCursor = new Date(startAt.getFullYear(), startAt.getMonth(), startAt.getDate())
+    while (dayCursor.getTime() < endExclusive.getTime()) {
+      const bucketKey = formatLocalDateKey(dayCursor)
+      appendPoint(bucketKey, bucketKey.slice(5).replace('-', '/'))
+      dayCursor = new Date(dayCursor.getFullYear(), dayCursor.getMonth(), dayCursor.getDate() + 1)
+    }
+    return points
   },
 
   buildDrilldownOrderRecord(row: {
@@ -741,16 +1054,36 @@ export const dashboardService = {
     }
   },
 
+  /**
+   * 组装饼图分片：
+   * - totalValue 传入区间全量总额时，被 Top N 截断掉的部分会汇总为一片“其他”；
+   * - 占比分母始终是全量总额，避免出现“分片加起来不是 100%”的误读。
+   */
   buildPieSlices(
     rows: Array<{ key: string; label: string; value: number }>,
-    normalizeValue: (value: number) => string = normalizeAmount,
+    options: { totalValue?: number; normalizeValue?: (value: number) => string } = {},
   ): DashboardPieSlice[] {
-    const totalValue = rows.reduce((sum, row) => sum + (Number.isFinite(row.value) ? row.value : 0), 0)
-    return rows.map((row) => ({
+    const normalizeValue = options.normalizeValue ?? normalizeAmount
+    const rowsTotal = rows.reduce((sum, row) => sum + (Number.isFinite(row.value) ? row.value : 0), 0)
+    const rawTotal = Number(options.totalValue)
+    const totalValue = Number.isFinite(rawTotal) && rawTotal > rowsTotal ? rawTotal : rowsTotal
+    const slices = rows.map((row) => ({
       key: row.key,
       label: row.label,
       value: normalizeValue(row.value),
       ratio: normalizeRatio(totalValue > 0 ? (row.value / totalValue) * 100 : 0),
     }))
+
+    const otherValue = totalValue - rowsTotal
+    if (otherValue > PIE_OTHER_EPSILON) {
+      slices.push({
+        key: PIE_OTHER_SLICE_KEY,
+        label: PIE_OTHER_SLICE_LABEL,
+        value: normalizeValue(otherValue),
+        ratio: normalizeRatio((otherValue / totalValue) * 100),
+      })
+    }
+
+    return slices
   }
 }

--- a/backend/src/types/dashboard.ts
+++ b/backend/src/types/dashboard.ts
@@ -50,7 +50,31 @@ export interface DashboardTagAggregateRaw {
 export interface DashboardPieProductRowRaw {
   key: string | number
   label: string | null
+  masterLabel?: string | null
   value: DashboardNumericLike
+}
+
+export interface DashboardRankProductRowRaw {
+  productId: string | number
+  masterName: string | null
+  snapshotName: string | null
+  totalQty: DashboardNumericLike
+}
+
+export interface DashboardRankCustomerRowRaw {
+  customerName: string | null
+  totalAmount: DashboardNumericLike
+  orderCount: DashboardNumericLike
+}
+
+export interface DashboardTrendOrderRowRaw {
+  createdAt: Date | string
+  totalAmount: DashboardNumericLike
+  totalQty: DashboardNumericLike
+}
+
+export interface DashboardAmountSumRaw {
+  totalValue?: DashboardNumericLike
 }
 
 export interface DashboardPieCustomerRowRaw {

--- a/docs/project-context/21-工作台、报表与出库链路.md
+++ b/docs/project-context/21-工作台、报表与出库链路.md
@@ -28,7 +28,10 @@
 
 ## 前端链路
 
-- Dashboard 页面显示四宫格、近 7 日趋势、Top 产品、Top 客户、最近动态，并支持钻取抽屉。
+- Dashboard 页面显示四宫格、结构占比饼图、出库趋势、Top 产品、Top 客户、最近动态，并支持钻取抽屉。
+- 首页“结构占比”区块内的统计区间筛选栏是唯一区间入口，同时驱动三个饼图、趋势图与两个榜单；
+  四宫格（今日/本月）与最近动态（审计事件流）不随区间变化。
+- 区间筛选状态收敛在 `src/views/dashboard/composables/useDashboardAnalytics.ts`，页面与卡片组件都不自行发起区间查询。
 - 出库开单页通过商品检索、数量编辑、汇总卡片和提交动作构造 `SubmitOrderPayload`。
 - 出库列表页负责筛选、详情抽屉、删除、恢复、永久删除以及合规标记编辑。
 - 报表中心按报表类型切换字段定义和导出行为，不同报表共用一个前端 API 模块。
@@ -36,9 +39,9 @@
 ## 后端链路
 
 - `dashboard.service.ts` 负责：
-  - 今日/本月统计
-  - 趋势聚合
-  - Top 产品/客户
+  - 今日/本月统计（`getStats`，固定口径，不接受区间入参）
+  - 区间分析（`getAnalytics`：趋势分桶 + Top 产品 + Top 客户）
+  - 结构占比饼图（`getDashboardPieData`）
   - 最近动态
   - 产品/客户/标签钻取
 - `order.service.ts` 负责：
@@ -56,6 +59,19 @@
 
 ## 关键状态/字段/快照
 
+- 商品榜有“合并 / 细分规格”两种维度：合并模式只按 `item.productId` 分组，名称取商品主表 `product_name`；
+  细分模式追加 `item.productNameSnapshot` 分组。两种模式的 Top N 都在 SQL 聚合完成之后才截断，
+  因此合并数量恒等于该商品全部规格数量之和。
+- 规格文本没有独立字段：`biz_outbound_order_item` 没有 `sku_id` 也没有 `spec_text_snapshot`，
+  规格只存在于 `product_name_snapshot` 里。O2O 预订核销写入的是“商品名（规格文本）”
+  （`o2o-preorder.service.ts`），手工开单写入的是纯商品名（`order.service.ts`）。
+  因此“细分规格”只对 O2O 核销单有意义，手工开单单据统一归为“默认规格”。
+- 饼图分片截断到 Top 8 后会补一片“其他”，占比分母是区间全量总额，卡片总额等于区间真实总额。
+- 趋势分桶在服务层用**本地时区**日期键完成，不使用任何数据库方言日期函数；
+  趋势查询必须走 `getMany()` 的实体水合，不能用 `getRawMany()`——原始结果会跳过驱动的时间归一化，
+  SQLite 会返回不带时区标记的 UTC 字符串并被重新按本地时间解析，导致整段趋势串日。
+- 统计区间统一左闭右开（`>= 起始日 00:00`、`< 结束日次日 00:00`），结束日整天都被覆盖；区间上限 366 天。
+
 - 出库单主字段：`showNo`、`orderType`、`customerDepartmentName`、`customerName`、`totalQty`、`totalAmount`、`isDeleted`。
 - 详情明细以快照优先：`productNameSnapshot`、`lineAmount`，避免商品后来改名影响历史单据展示。
 - O2O 关联出库单通过 `idempotencyKey` 前缀识别，与预订单删除可见性联动。
@@ -71,6 +87,9 @@
 
 1. 工作台数字不对：先查 `dashboard.service.ts` 的过滤条件是否排除了软删除单据。
 2. 趋势图或排行榜和列表不一致：查 Dashboard 与报表是否使用了不同时间范围或订单类型过滤。
+3. 商品榜出现同名不同色重复条目：查 `getAnalytics` 的 `productSpecMode` 是否被切到 `spec`，
+   以及是否有人重新给商品榜查询加回了 `addGroupBy('item.productNameSnapshot')`。
+4. 榜单/饼图和下钻抽屉对不上：查抽屉是否透传了当前 `appliedFilter`（区间 + 订单类型 + 规格快照）。
 3. 出库单重复提交：查 `idempotencyKey` 是否缺失或前端重复生成策略异常。
 4. 删除后流水号回拨异常：查 `order.service.ts` 的 `recalibrateCurrentFromOccupancy()`。
 5. O2O 关联出库单删除后预订单看不见/看得见不对：查关联可见性同步逻辑。
@@ -78,5 +97,6 @@
 ## 验证与回归关注点
 
 - 出库链路至少回归：新建订单、详情查看、软删、恢复、永久删、合规标记编辑。
-- 工作台回归：四宫格、趋势、钻取、近期动态文案。
+- 工作台回归：四宫格、区间筛选（按日/按月、跨月跨年）、饼图、趋势、商品榜合并/细分、Top N 切换、钻取、近期动态文案。
+- 工作台自动化回归命令：`npm --prefix backend run dashboard:analytics:verify`。
 - 报表回归：报表类型切换、字段列头、分页、导出文件名。

--- a/scripts/verify-unit-functional-suite.mjs
+++ b/scripts/verify-unit-functional-suite.mjs
@@ -97,6 +97,12 @@ const main = async () => {
   // - 同时覆盖 Task8 迁移脚本、凭证打印链路与看板下钻的静态与运行态契约。
   await runNpmScript('后端双流水单号与并发写事务回归', 'task8:verify', backendRoot)
 
+  // 首页区间分析回归（issue #60）：
+  // - 覆盖跨月跨年区间的边界包含、空区间与非法起止时间反馈；
+  // - 守住“商品榜默认按商品合并、可切换细分规格”的口径，以及“先完整聚合再截断 Top N”；
+  // - 同时校验趋势分桶使用本地时区，避免凌晨单据被 UTC 转换算到前一天。
+  await runNpmScript('后端首页区间分析回归', 'dashboard:analytics:verify', backendRoot)
+
   log('\n[unit-functional] 单元功能测试套件执行完成')
 }
 

--- a/src/api/modules/dashboard.ts
+++ b/src/api/modules/dashboard.ts
@@ -1,6 +1,6 @@
 /**
  * 模块说明：`src/api/modules/dashboard.ts`
- * 文件职责：封装管理端工作台统计、排行、近期动态与下钻查询接口。
+ * 文件职责：封装管理端工作台统计、区间分析、排行、近期动态与下钻查询接口。
  * 实现逻辑：
  * 1. 统一声明看板接口返回结构，保证页面与组件消费同一份类型契约；
  * 2. 最近动态字段显式包含真实订单ID与展示名称，供工作台点击跳单与文案展示复用；
@@ -15,9 +15,6 @@ export interface DashboardStats {
   totalProductCount: number
   monthOrderCount: number
   monthOrderAmount: string | number
-  trend7Days: DashboardTrendPoint[]
-  topProducts: DashboardTopProduct[]
-  topCustomers: DashboardTopCustomer[]
   recentActivities: DashboardRecentActivity[]
 }
 
@@ -30,8 +27,14 @@ export interface DashboardTrendPoint {
 }
 
 export interface DashboardTopProduct {
+  /** 榜单行唯一键：合并模式为 productId，细分模式为 `productId::名称快照`。 */
+  rankKey: string
   productId: string
   productName: string
+  /** 合并模式为 null；细分模式为解析出的规格文本（无规格时为“默认规格”）。 */
+  specLabel: string | null
+  /** 细分模式下该行对应的出库明细名称快照，供下钻精确过滤；合并模式为 null。 */
+  nameSnapshot: string | null
   totalQty: string | number
 }
 
@@ -58,6 +61,34 @@ export interface DashboardRecentActivity {
 export interface DashboardDateFilterQuery {
   dateRange?: [string, string] | null
   orderType?: 'department' | 'walkin'
+}
+
+export type DashboardTrendGranularity = 'day' | 'month'
+export type DashboardProductSpecMode = 'merged' | 'spec'
+
+export interface DashboardAnalyticsQuery extends DashboardDateFilterQuery {
+  granularity?: DashboardTrendGranularity
+  productSpecMode?: DashboardProductSpecMode
+  productId?: string
+  topN?: number
+}
+
+export interface DashboardAnalyticsRange {
+  startDate: string
+  endDate: string
+  granularity: DashboardTrendGranularity
+  orderType: 'department' | 'walkin' | null
+  productSpecMode: DashboardProductSpecMode
+  productId: string | null
+  topN: number
+  isDefault: boolean
+}
+
+export interface DashboardAnalyticsResult {
+  range: DashboardAnalyticsRange
+  trend: DashboardTrendPoint[]
+  topProducts: DashboardTopProduct[]
+  topCustomers: DashboardTopCustomer[]
 }
 
 export interface DashboardDrilldownOrderRecord {
@@ -109,6 +140,12 @@ export interface DashboardPieDataResult {
   productPie: DashboardPieSlice[]
   customerPie: DashboardPieSlice[]
   orderTypePie: DashboardPieSlice[]
+  range: {
+    startDate: string
+    endDate: string
+    orderType: 'department' | 'walkin' | null
+    isDefault: boolean
+  }
 }
 
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
@@ -148,15 +185,17 @@ export const getDashboardStats = (requestConfig: RequestConfig = {}) => {
  */
 export const getProductDrilldown = (
   productId: string,
-  query: DashboardDateFilterQuery = {},
+  query: DashboardDateFilterQuery & { nameSnapshot?: string } = {},
   requestConfig: RequestConfig = {},
 ) => {
+  const nameSnapshot = query.nameSnapshot?.trim()
   return request<ProductDrilldownResult>({
     ...requestConfig,
     url: '/dashboard/drilldown/products',
     method: 'GET',
     params: {
       productId,
+      ...(nameSnapshot ? { nameSnapshot } : {}),
       ...buildDashboardDateFilterParams(query),
     },
   })
@@ -199,6 +238,39 @@ export const getTagAggregate = (
       tagId,
       ...buildDashboardDateFilterParams(query),
     },
+  })
+}
+
+/**
+ * 获取首页区间分析数据：
+ * - 由“结构占比”筛选栏统一驱动趋势图、热门商品榜与部门榜；
+ * - 商品榜默认按商品合并，可切换细分规格并锁定单个商品做款式对比。
+ */
+export const getDashboardAnalytics = (
+  query: DashboardAnalyticsQuery = {},
+  requestConfig: RequestConfig = {},
+) => {
+  const params: Record<string, string | number> = {
+    ...buildDashboardDateFilterParams(query),
+  }
+  if (query.granularity) {
+    params.granularity = query.granularity
+  }
+  if (query.productSpecMode) {
+    params.productSpecMode = query.productSpecMode
+  }
+  if (query.productId?.trim()) {
+    params.productId = query.productId.trim()
+  }
+  if (query.topN) {
+    params.topN = query.topN
+  }
+
+  return request<DashboardAnalyticsResult>({
+    ...requestConfig,
+    url: '/dashboard/analytics',
+    method: 'GET',
+    params,
   })
 }
 

--- a/src/components/charts/echarts.ts
+++ b/src/components/charts/echarts.ts
@@ -2,22 +2,26 @@
  * 模块说明：src/components/charts/echarts.ts
  * 文件职责：集中注册前端图表层当前使用到的 ECharts 渲染器、图表类型与组件插件，供共享图表组件复用。
  * 实现逻辑：
- * - 按需引入 Canvas 渲染器、折线图、饼图和常用提示/图例/网格组件，避免整包注册带来的体积浪费；
+ * - 只注册当前图表真实用到的能力：Canvas 渲染器、折线图、饼图、提示框与直角坐标系网格；
  * - 把图表注册动作收口到单独文件，保证所有图表页面共用同一注册入口；
  * - 基础图表组件只需导入该文件即可完成依赖初始化，不必在每个图表页重复注册。
+ * 维护说明：
+ * - 这里是“用到什么才注册什么”，不是“先全注册以备不时之需”：ECharts 的每个组件都会实打实地
+ *   进入 charting 分包，注册了却不用等于白付体积（曾经注册的 LegendComponent 与 GraphicComponent
+ *   全仓库无人使用，占了约 30 KB）；
+ * - 因此新写图表时若用到 legend、graphic、dataZoom、markLine、visualMap 等 option 键，
+ *   必须先在本文件补上对应组件的注册，否则该配置会静默失效并在控制台留下告警。
  */
 
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { PieChart, LineChart } from 'echarts/charts'
-import { TooltipComponent, LegendComponent, GridComponent, GraphicComponent } from 'echarts/components'
+import { TooltipComponent, GridComponent } from 'echarts/components'
 
 use([
   CanvasRenderer,
   PieChart,
   LineChart,
   TooltipComponent,
-  LegendComponent,
   GridComponent,
-  GraphicComponent,
 ])

--- a/src/views/dashboard/DashboardView.vue
+++ b/src/views/dashboard/DashboardView.vue
@@ -38,6 +38,7 @@ const loadStatus = ref<'idle' | 'success' | 'error' | 'canceled'>('idle')
 const dashboardRequest = useStableRequest()
 const {
   analyticsLoading,
+  analyticsError,
   trend,
   topProducts,
   topCustomers,
@@ -504,6 +505,7 @@ onActivated(() => {
           v-model:range-value="draftFilter.rangeValue"
           v-model:order-type="draftFilter.orderType"
           :loading="analyticsLoading"
+          :error-message="analyticsError"
           :range-label="rangeLabel"
           :granularity-label="granularityLabel"
           :order-type-label="orderTypeLabel"

--- a/src/views/dashboard/DashboardView.vue
+++ b/src/views/dashboard/DashboardView.vue
@@ -39,6 +39,7 @@ const dashboardRequest = useStableRequest()
 const {
   analyticsLoading,
   analyticsError,
+  ensureAnalyticsReady,
   trend,
   topProducts,
   topCustomers,
@@ -287,9 +288,9 @@ const ensureDashboardReady = () => {
     void loadData()
   }
   // 区间统计与概览分属两个接口，keep-alive 恢复时同样需要兜底一次。
-  if (!trend.value.length && !analyticsLoading.value) {
-    void loadAnalytics()
-  }
+  // 判定交给 ensureAnalyticsReady：它以“数据是否对应当前筛选条件”为准，
+  // 而不是“有没有数据”——否则新区间的请求被离页取消后，重新进入会一直显示旧区间的榜单。
+  ensureAnalyticsReady()
 }
 
 /**
@@ -301,6 +302,7 @@ const retryLoadData = () => {
   void loadData()
   void loadAnalytics()
 }
+
 
 onMounted(() => {
   ensureDashboardReady()

--- a/src/views/dashboard/DashboardView.vue
+++ b/src/views/dashboard/DashboardView.vue
@@ -6,7 +6,9 @@
  * 1. 页面通过看板聚合接口一次性拉取首屏所需统计、排行和近期动态，减少首屏碎片请求；
  * 2. 近期动态点击后会把真实订单ID与单号透传给出库单列表页，复用列表页既有“定位并打开详情抽屉”流程；
  * 3. 动态副标题优先展示部门名称，散客或历史日志缺部门信息时再回退客户名称；
- * 4. 页面保留 keep-alive 场景下的可恢复加载逻辑，避免请求取消后再次进入出现空白首页。
+ * 4. 页面保留 keep-alive 场景下的可恢复加载逻辑，避免请求取消后再次进入出现空白首页；
+ * 5. “结构占比”区块的统计区间筛选栏由 useDashboardAnalytics 统一维护，并同时驱动饼图、出库趋势与两个排行榜，
+ *    核心看板四宫格保持“今日/本月”固定口径，近期动态是审计事件流，两者都不随区间变化。
  */
 
 
@@ -22,6 +24,7 @@ import { buildDashboardShortcutItems } from '@/router/routes'
 import { useAppStore, useAuthStore } from '@/store'
 import pinia from '@/store/pinia'
 import { extractErrorMessage } from '@/utils/error'
+import { useDashboardAnalytics } from './composables/useDashboardAnalytics'
 
 
 import { showAppError } from '@/utils/app-alert'
@@ -33,6 +36,24 @@ const loading = ref(false)
 const stats = ref<DashboardStats | null>(null)
 const loadStatus = ref<'idle' | 'success' | 'error' | 'canceled'>('idle')
 const dashboardRequest = useStableRequest()
+const {
+  analyticsLoading,
+  trend,
+  topProducts,
+  topCustomers,
+  draftFilter,
+  appliedFilter,
+  rankOptions,
+  rangeLabel,
+  granularityLabel,
+  orderTypeLabel,
+  loadAnalytics,
+  handleGranularityChange,
+  handleSearch: handleAnalyticsSearch,
+  handleReset: handleAnalyticsReset,
+  handleRankOptionsChange,
+} = useDashboardAnalytics()
+const DashboardFilterBar = defineAsyncComponent(() => import('./components/DashboardFilterBar.vue'))
 const DashboardPieSection = defineAsyncComponent(() => import('./components/DashboardPieSection.vue'))
 const TrendChartCard = defineAsyncComponent(() => import('./components/TrendChartCard.vue'))
 const TopProductRankCard = defineAsyncComponent(() => import('./components/TopProductRankCard.vue'))
@@ -264,6 +285,10 @@ const ensureDashboardReady = () => {
   if (!stats.value && !loading.value) {
     void loadData()
   }
+  // 区间统计与概览分属两个接口，keep-alive 恢复时同样需要兜底一次。
+  if (!trend.value.length && !analyticsLoading.value) {
+    void loadAnalytics()
+  }
 }
 
 /**
@@ -273,6 +298,7 @@ const ensureDashboardReady = () => {
  */
 const retryLoadData = () => {
   void loadData()
+  void loadAnalytics()
 }
 
 onMounted(() => {
@@ -471,16 +497,49 @@ onActivated(() => {
         </div>
       </section>
 
-      <DashboardPieSection />
+      <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">结构占比</h2>
+        <DashboardFilterBar
+          v-model:granularity="draftFilter.granularity"
+          v-model:range-value="draftFilter.rangeValue"
+          v-model:order-type="draftFilter.orderType"
+          :loading="analyticsLoading"
+          :range-label="rangeLabel"
+          :granularity-label="granularityLabel"
+          :order-type-label="orderTypeLabel"
+          @granularity-change="handleGranularityChange"
+          @search="handleAnalyticsSearch"
+          @reset="handleAnalyticsReset"
+        />
+        <DashboardPieSection :filter="appliedFilter" :range-label="rangeLabel" />
+      </section>
 
       <div :class="['grid gap-6 xl:gap-7', appStore.isDesktop ? 'xl:grid-cols-[1.3fr_1fr] lg:grid-cols-[1.2fr_1fr]' : 'grid-cols-1']">
         <section>
-          <TrendChartCard :trend="stats?.trend7Days ?? []" />
+          <TrendChartCard
+            :trend="trend"
+            :range-label="rangeLabel"
+            :granularity-label="granularityLabel"
+            :loading="analyticsLoading"
+          />
         </section>
 
         <section class="space-y-6">
-          <TopProductRankCard :top-products="stats?.topProducts ?? []" />
-          <TopCustomerRankCard :top-customers="stats?.topCustomers ?? []" />
+          <TopProductRankCard
+            :top-products="topProducts"
+            :options="rankOptions"
+            :filter="appliedFilter"
+            :range-label="rangeLabel"
+            :loading="analyticsLoading"
+            @update:options="handleRankOptionsChange"
+          />
+          <TopCustomerRankCard
+            :top-customers="topCustomers"
+            :options="rankOptions"
+            :filter="appliedFilter"
+            :range-label="rangeLabel"
+            :loading="analyticsLoading"
+          />
 
           <div class="apple-card p-5 sm:p-6 xl:p-7">
             <h2 class="mb-4 text-lg font-semibold text-slate-800 dark:text-slate-200">近期出库动态</h2>

--- a/src/views/dashboard/components/DashboardFilterBar.vue
+++ b/src/views/dashboard/components/DashboardFilterBar.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+/**
+ * 模块说明：src/views/dashboard/components/DashboardFilterBar.vue
+ * 文件职责：提供工作台首页统一的统计区间筛选栏，同时驱动结构占比饼图、出库趋势与两个排行榜。
+ * 实现逻辑：
+ * - 支持“按日 / 按月”两种粒度：按月模式使用 monthrange，由上层展开为首月 1 日至末月最后一日，保证跨月跨年区间完整覆盖；
+ * - 区间与订单类型属于草稿态，点击“查询统计”后才提交，避免用户还在拖日期时反复触发接口；
+ * - 筛选栏内展示后端回执的真实生效区间，杜绝“选了自定义区间，标题仍写本月”的口径错位。
+ * 维护说明：
+ * - 新增筛选维度时同步扩展 useDashboardAnalytics 的草稿态，不要在本组件里私自发起请求；
+ * - 区间文案必须以后端返回的 range 为准，前端不得自行推断默认区间后展示。
+ */
+
+import type { DashboardTrendGranularity } from '@/api/modules/dashboard'
+import type { DashboardOrderTypeFilter } from '../composables/useDashboardAnalytics'
+import { useAppStore } from '@/store'
+import pinia from '@/store/pinia'
+
+const appStore = useAppStore(pinia)
+
+const props = defineProps<{
+  granularity: DashboardTrendGranularity
+  rangeValue: [string, string] | []
+  orderType: DashboardOrderTypeFilter
+  loading: boolean
+  rangeLabel: string
+  granularityLabel: string
+  orderTypeLabel: string
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:granularity', value: DashboardTrendGranularity): void
+  (event: 'update:rangeValue', value: [string, string] | []): void
+  (event: 'update:orderType', value: DashboardOrderTypeFilter): void
+  (event: 'granularity-change'): void
+  (event: 'search'): void
+  (event: 'reset'): void
+}>()
+
+const rangeControlClass = appStore.isPhone ? '!w-full' : appStore.isTablet ? '!w-[320px]' : '!w-[340px]'
+const selectControlClass = appStore.isPhone ? '!w-full' : appStore.isTablet ? '!w-[150px]' : '!w-[160px]'
+
+// 详细注释：切换粒度后已选值不再适用，交由上层清空，避免把月份值当作日期提交。
+const handleGranularityChange = (value: DashboardTrendGranularity) => {
+  emit('update:granularity', value)
+  emit('granularity-change')
+}
+</script>
+
+<template>
+  <div class="apple-card p-4 sm:p-5 xl:p-6">
+    <div class="flex flex-wrap items-center gap-3">
+      <el-radio-group
+        :model-value="props.granularity"
+        :class="appStore.isPhone ? 'w-full' : ''"
+        @update:model-value="handleGranularityChange($event as DashboardTrendGranularity)"
+      >
+        <el-radio-button value="day">按日</el-radio-button>
+        <el-radio-button value="month">按月</el-radio-button>
+      </el-radio-group>
+
+      <el-date-picker
+        v-if="props.granularity === 'month'"
+        :model-value="props.rangeValue"
+        type="monthrange"
+        unlink-panels
+        value-format="YYYY-MM"
+        range-separator="至"
+        start-placeholder="开始月份"
+        end-placeholder="结束月份"
+        :class="rangeControlClass"
+        @update:model-value="emit('update:rangeValue', ($event as [string, string] | null) ?? [])"
+      />
+      <el-date-picker
+        v-else
+        :model-value="props.rangeValue"
+        type="daterange"
+        unlink-panels
+        value-format="YYYY-MM-DD"
+        range-separator="至"
+        start-placeholder="开始日期"
+        end-placeholder="结束日期"
+        :class="rangeControlClass"
+        @update:model-value="emit('update:rangeValue', ($event as [string, string] | null) ?? [])"
+      />
+
+      <el-select
+        :model-value="props.orderType"
+        clearable
+        placeholder="订单类型"
+        :class="selectControlClass"
+        @update:model-value="emit('update:orderType', ($event as DashboardOrderTypeFilter) ?? '')"
+      >
+        <el-option label="部门单" value="department" />
+        <el-option label="散客单" value="walkin" />
+      </el-select>
+
+      <div :class="['flex gap-2', appStore.isPhone ? 'w-full' : '']">
+        <el-button :class="appStore.isPhone ? 'flex-1' : ''" type="primary" :loading="props.loading" @click="emit('search')">
+          查询统计
+        </el-button>
+        <el-button :class="appStore.isPhone ? 'flex-1' : ''" :disabled="props.loading" @click="emit('reset')">
+          重置条件
+        </el-button>
+      </div>
+    </div>
+
+    <div class="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+      <span>
+        当前统计区间：
+        <span class="font-semibold text-slate-700 dark:text-slate-200">{{ props.rangeLabel }}</span>
+      </span>
+      <span class="hidden sm:inline">·</span>
+      <span>趋势粒度：{{ props.granularityLabel }}</span>
+      <span class="hidden sm:inline">·</span>
+      <span>{{ props.orderTypeLabel }}</span>
+      <span class="w-full text-[11px] text-slate-400 dark:text-slate-500">
+        未选择区间时默认统计本月；饼图、趋势与榜单均以此区间为准。
+      </span>
+    </div>
+  </div>
+</template>

--- a/src/views/dashboard/components/DashboardFilterBar.vue
+++ b/src/views/dashboard/components/DashboardFilterBar.vue
@@ -11,6 +11,8 @@
  * - 区间文案必须以后端返回的 range 为准，前端不得自行推断默认区间后展示。
  */
 
+import { WarningFilled } from '@element-plus/icons-vue'
+
 import type { DashboardTrendGranularity } from '@/api/modules/dashboard'
 import type { DashboardOrderTypeFilter } from '../composables/useDashboardAnalytics'
 import { useAppStore } from '@/store'
@@ -23,6 +25,8 @@ const props = defineProps<{
   rangeValue: [string, string] | []
   orderType: DashboardOrderTypeFilter
   loading: boolean
+  /** 区间查询失败时的错误文案，非空时替代“当前统计区间”提示，避免旧口径继续被当成有效结果。 */
+  errorMessage: string
   rangeLabel: string
   granularityLabel: string
   orderTypeLabel: string
@@ -105,7 +109,11 @@ const handleGranularityChange = (value: DashboardTrendGranularity) => {
       </div>
     </div>
 
-    <div class="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+    <div v-if="props.errorMessage" class="mt-3 flex items-start gap-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600 dark:bg-red-500/10 dark:text-red-400">
+      <el-icon :size="14" class="mt-0.5 shrink-0"><WarningFilled /></el-icon>
+      <span>{{ props.errorMessage }}（请调整起止时间后重试，下方图表与榜单已清空）</span>
+    </div>
+    <div v-else class="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
       <span>
         当前统计区间：
         <span class="font-semibold text-slate-700 dark:text-slate-200">{{ props.rangeLabel }}</span>

--- a/src/views/dashboard/components/DashboardPieSection.vue
+++ b/src/views/dashboard/components/DashboardPieSection.vue
@@ -14,7 +14,7 @@
  */
 
 
-import { computed, ref, watch } from 'vue'
+import { computed, onActivated, onBeforeUnmount, onDeactivated, ref, watch } from 'vue'
 import type { EChartsOption } from 'echarts'
 
 import { Document, Money } from '@element-plus/icons-vue'
@@ -38,6 +38,8 @@ const themeStore = useThemeStore(pinia)
 const pieRequest = useStableRequest()
 const pieLoading = ref(false)
 const pieData = ref<DashboardPieDataResult | null>(null)
+/** 最近一次饼图查询的错误文案：非空时不得继续展示上一次的成功结果。 */
+const pieError = ref('')
 const piePalette = ['#14b8a6', '#0ea5e9', '#8b5cf6', '#f97316', '#eab308', '#ef4444', '#84cc16', '#06b6d4']
 type PieValueType = 'amount' | 'count'
 type NumericLike = string | number | null | undefined
@@ -169,6 +171,7 @@ const buildPieOption = (slices: readonly DashboardPieSlice[], valueType: PieValu
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
 const loadPieData = async () => {
   pieLoading.value = true
+  pieError.value = ''
   await pieRequest.runLatest({
     executor: (signal) =>
       getDashboardPieData(
@@ -179,19 +182,46 @@ const loadPieData = async () => {
         { signal },
       ),
     onSuccess: (result) => {
+      pieError.value = ''
       pieData.value = result
     },
     onError: (error) => {
-      showAppError(extractErrorMessage(error, '获取饼图统计失败'))
+      // 区间已经切到新条件，若留着上一次的成功结果，用户会把旧占比当成新筛选的结果读。
+      const message = extractErrorMessage(error, '获取饼图统计失败')
+      pieError.value = message
+      pieData.value = null
+      showAppError(message)
     },
-    onFinally: ({ status }) => {
-      // 请求被新筛选中止时保持加载态，避免旧请求收尾时闪出一次空态。
-      if (status !== 'canceled') {
-        pieLoading.value = false
-      }
+    onFinally: () => {
+      pieLoading.value = false
     },
   })
 }
+
+/**
+ * 失活与卸载时复位加载态：
+ * - useStableRequest 的 cancel() 会把 activeController 置空，runLatest 随后判定当前请求已过期
+ *   而直接返回，onFinally 不会被调用；
+ * - 不复位的话，keep-alive 页面在请求未完成时离开，pieLoading 会永久为 true，三张饼图卡片
+ *   会一直停在骨架屏，直到用户再次改动筛选条件。
+ */
+const resetLoadingOnLeave = () => {
+  pieLoading.value = false
+}
+
+onDeactivated(resetLoadingOnLeave)
+onBeforeUnmount(resetLoadingOnLeave)
+
+/**
+ * 重新进入 keep-alive 页面时兜底：
+ * - 上次请求若在离页时被取消，这里没有数据也不会再自动触发（watch 只在筛选条件变化时响应），
+ *   因此需要补一次拉取，避免卡在空态。
+ */
+onActivated(() => {
+  if (!pieData.value && !pieLoading.value) {
+    void loadPieData()
+  }
+})
 
 watch(
   () => props.filter,
@@ -250,7 +280,7 @@ watch(
         </div>
       </div>
       <div v-else class="flex min-h-[220px] items-center justify-center rounded-xl bg-slate-50 dark:bg-slate-900/40">
-        <el-empty :image-size="64" :description="card.emptyText" />
+        <el-empty :image-size="64" :description="pieError || card.emptyText" />
       </div>
     </div>
   </div>

--- a/src/views/dashboard/components/DashboardPieSection.vue
+++ b/src/views/dashboard/components/DashboardPieSection.vue
@@ -40,6 +40,13 @@ const pieLoading = ref(false)
 const pieData = ref<DashboardPieDataResult | null>(null)
 /** 最近一次饼图查询的错误文案：非空时不得继续展示上一次的成功结果。 */
 const pieError = ref('')
+/**
+ * 当前展示数据对应的筛选条件签名：
+ * - 与榜单同理，不能用“有没有数据”当重入门禁；
+ * - 新区间的请求若在离页时被取消，重新进入必须补跑，否则饼图会一直停在旧区间口径上。
+ */
+const loadedFilterSignature = ref('')
+const buildFilterSignature = () => JSON.stringify(props.filter)
 const piePalette = ['#14b8a6', '#0ea5e9', '#8b5cf6', '#f97316', '#eab308', '#ef4444', '#84cc16', '#06b6d4']
 type PieValueType = 'amount' | 'count'
 type NumericLike = string | number | null | undefined
@@ -170,6 +177,8 @@ const buildPieOption = (slices: readonly DashboardPieSlice[], valueType: PieValu
 
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
 const loadPieData = async () => {
+  // 在发起请求时固定签名，回写时才能对应本次真正请求的那一组条件。
+  const requestSignature = buildFilterSignature()
   pieLoading.value = true
   pieError.value = ''
   await pieRequest.runLatest({
@@ -183,12 +192,14 @@ const loadPieData = async () => {
       ),
     onSuccess: (result) => {
       pieError.value = ''
+      loadedFilterSignature.value = requestSignature
       pieData.value = result
     },
     onError: (error) => {
       // 区间已经切到新条件，若留着上一次的成功结果，用户会把旧占比当成新筛选的结果读。
       const message = extractErrorMessage(error, '获取饼图统计失败')
       pieError.value = message
+      loadedFilterSignature.value = ''
       pieData.value = null
       showAppError(message)
     },
@@ -214,11 +225,12 @@ onBeforeUnmount(resetLoadingOnLeave)
 
 /**
  * 重新进入 keep-alive 页面时兜底：
- * - 上次请求若在离页时被取消，这里没有数据也不会再自动触发（watch 只在筛选条件变化时响应），
- *   因此需要补一次拉取，避免卡在空态。
+ * - 上次请求若在离页时被取消，watch 只在筛选条件变化时响应，不会自动补跑；
+ * - 判定以“已加载数据是否对应当前条件”为准，而不是“有没有数据”：
+ *   否则用户提交新区间后立即离页，重新进入时饼图会一直停在旧区间的占比上。
  */
 onActivated(() => {
-  if (!pieData.value && !pieLoading.value) {
+  if (loadedFilterSignature.value !== buildFilterSignature() && !pieLoading.value) {
     void loadPieData()
   }
 })

--- a/src/views/dashboard/components/DashboardPieSection.vue
+++ b/src/views/dashboard/components/DashboardPieSection.vue
@@ -3,69 +3,78 @@
  * 模块说明：src/views/dashboard/components/DashboardPieSection.vue
  * 文件职责：负责仪表盘饼图分区的统计展示，统一输出订单结构、金额结构等占比信息及对应状态反馈。
  * 实现逻辑：
- * - 组件在本地管理饼图切换、加载态和空态，只消费上游接口返回的结构化统计数据；
- * - 图表区与摘要区保持同一口径，避免卡片数字和饼图分片含义不一致。
+ * - 统计区间由上层统一下发，本组件只在区间变化时重新拉取饼图数据，保证与趋势图、榜单同口径；
+ * - 图表区与摘要区保持同一口径，避免卡片数字和饼图分片含义不一致；
+ * - 商品占比按商品合并统计，同一商品的不同颜色/规格不再裂成多片；被 Top N 截断的部分由后端汇总为“其他”，
+ *   因此卡片总额等于区间真实总额、各分片占比之和为 100%。
  * 维护说明：
  * - 若后续新增统计口径，需要同步补充分片标签、图例文案和空态提示；
- * - 仪表盘图表展示必须优先保证清晰可读，不要因为装饰性动画影响首屏性能。
+ * - 仪表盘图表展示必须优先保证清晰可读，不要因为装饰性动画影响首屏性能；
+ * - 请求竞态交给 useStableRequest，不要再加 `if (loading) return` 早退守卫，否则快速切区间会吞掉新请求。
  */
 
 
-import { computed, reactive, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { EChartsOption } from 'echarts'
 
 import { Document, Money } from '@element-plus/icons-vue'
 import BaseEChart from '@/components/charts/BaseEChart.vue'
 import { getDashboardPieData, type DashboardPieDataResult, type DashboardPieSlice } from '@/api/modules/dashboard'
 import { useStableRequest } from '@/composables/useStableRequest'
-import { useAppStore, useThemeStore } from '@/store'
+import { useThemeStore } from '@/store'
 import pinia from '@/store/pinia'
 import { extractErrorMessage } from '@/utils/error'
 import { escapeTooltipHtml } from '@/utils/html-escape'
+import type { DashboardAppliedFilter } from '../composables/useDashboardAnalytics'
 
 import { showAppError } from '@/utils/app-alert'
 
-const appStore = useAppStore(pinia)
+const props = defineProps<{
+  filter: DashboardAppliedFilter
+  rangeLabel: string
+}>()
+
 const themeStore = useThemeStore(pinia)
 const pieRequest = useStableRequest()
 const pieLoading = ref(false)
-const pieData = ref<DashboardPieDataResult>({
-  productPie: [],
-  customerPie: [],
-  orderTypePie: [],
-})
-const filterForm = reactive({
-  dateRange: [] as [string, string] | [],
-  orderType: '' as '' | 'department' | 'walkin',
-})
+const pieData = ref<DashboardPieDataResult | null>(null)
 const piePalette = ['#14b8a6', '#0ea5e9', '#8b5cf6', '#f97316', '#eab308', '#ef4444', '#84cc16', '#06b6d4']
 type PieValueType = 'amount' | 'count'
 type NumericLike = string | number | null | undefined
+
+/** 饼图区间文案优先使用饼图接口自己的回执，避免与榜单区间不一致时误导用户。 */
+const pieRangeLabel = computed(() => {
+  const range = pieData.value?.range
+  if (range?.startDate && range?.endDate) {
+    return `${range.startDate} 至 ${range.endDate}`
+  }
+  return props.rangeLabel
+})
 
 const pieCards = computed(() => {
   return [
     {
       key: 'productPie',
       title: '商品金额占比',
-      description: '按商品维度统计出库金额占比',
-      slices: pieData.value.productPie,
-      emptyText: '暂无商品占比数据',
+      description: `按商品维度统计出库金额占比（${pieRangeLabel.value}）`,
+      slices: pieData.value?.productPie ?? [],
+      emptyText: '所选区间暂无商品占比数据',
       valueType: 'amount' as PieValueType,
     },
     {
       key: 'customerPie',
       title: '客户金额占比',
-      description: '按部门/散客维度统计出库金额占比',
-      slices: pieData.value.customerPie,
-      emptyText: '暂无客户占比数据',
+      description: `按部门/散客维度统计出库金额占比（${pieRangeLabel.value}）`,
+      slices: pieData.value?.customerPie ?? [],
+      emptyText: '所选区间暂无客户占比数据',
       valueType: 'amount' as PieValueType,
     },
     {
       key: 'orderTypePie',
       title: '散客/部门单数占比',
-      description: '按订单类型统计出库单数占比',
-      slices: pieData.value.orderTypePie,
-      emptyText: '暂无订单类型占比数据',
+      description: `按订单类型统计出库单数占比（${pieRangeLabel.value}）`,
+      slices: pieData.value?.orderTypePie ?? [],
+      emptyText: '所选区间暂无订单类型占比数据',
       valueType: 'count' as PieValueType,
     },
   ] as const
@@ -92,12 +101,12 @@ const resolvePieLegendColor = (index: number): string => {
   return piePalette[index % piePalette.length]
 }
 
-const getCardTotalValue = (slices: DashboardPieSlice[]) => {
+const getCardTotalValue = (slices: readonly DashboardPieSlice[]) => {
   return slices.reduce((sum, item) => sum + Number(item.value ?? 0), 0)
 }
 
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
-const buildPieOption = (slices: DashboardPieSlice[], valueType: PieValueType): EChartsOption => {
+const buildPieOption = (slices: readonly DashboardPieSlice[], valueType: PieValueType): EChartsOption => {
   return {
     color: piePalette,
     animationDuration: themeStore.prefersReducedMotion ? 0 : 400,
@@ -158,146 +167,91 @@ const buildPieOption = (slices: DashboardPieSlice[], valueType: PieValueType): E
 }
 
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
-const buildQuery = () => {
-  const query: {
-    dateRange?: [string, string]
-    orderType?: 'department' | 'walkin'
-  } = {}
-
-  if (filterForm.dateRange.length === 2) {
-    query.dateRange = [filterForm.dateRange[0], filterForm.dateRange[1]]
-  }
-  if (filterForm.orderType) {
-    query.orderType = filterForm.orderType
-  }
-
-  return query
-}
-
-// 详细注释：此处承接当前模块的关键状态、流程或结构定义。
 const loadPieData = async () => {
-  if (pieLoading.value) {
-    return
-  }
-
   pieLoading.value = true
   await pieRequest.runLatest({
-    executor: (signal) => getDashboardPieData(buildQuery(), { signal }),
+    executor: (signal) =>
+      getDashboardPieData(
+        {
+          dateRange: props.filter.dateRange,
+          orderType: props.filter.orderType || undefined,
+        },
+        { signal },
+      ),
     onSuccess: (result) => {
-      pieData.value = {
-        productPie: result.productPie ?? [],
-        customerPie: result.customerPie ?? [],
-        orderTypePie: result.orderTypePie ?? [],
-      }
+      pieData.value = result
     },
     onError: (error) => {
       showAppError(extractErrorMessage(error, '获取饼图统计失败'))
     },
-    onFinally: () => {
-      pieLoading.value = false
+    onFinally: ({ status }) => {
+      // 请求被新筛选中止时保持加载态，避免旧请求收尾时闪出一次空态。
+      if (status !== 'canceled') {
+        pieLoading.value = false
+      }
     },
   })
 }
 
-// 详细注释：此处承接当前模块的关键状态、流程或结构定义。
-const handleFilterSearch = () => {
-  void loadPieData()
-}
-
-// 详细注释：此处承接当前模块的关键状态、流程或结构定义。
-const handleFilterReset = () => {
-  filterForm.dateRange = []
-  filterForm.orderType = ''
-  void loadPieData()
-}
-
-void loadPieData()
+watch(
+  () => props.filter,
+  () => {
+    void loadPieData()
+  },
+  { deep: true, immediate: true },
+)
 </script>
 
 <template>
-  <section class="space-y-4">
-    <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">结构占比</h2>
-    <div class="apple-card p-4 sm:p-5 xl:p-6">
-      <div class="flex flex-wrap items-center gap-3">
-        <el-date-picker
-          v-model="filterForm.dateRange"
-          type="daterange"
-          unlink-panels
-          value-format="YYYY-MM-DD"
-          range-separator="至"
-          start-placeholder="开始日期"
-          end-placeholder="结束日期"
-          :class="appStore.isPhone ? '!w-full' : appStore.isTablet ? '!w-[320px]' : '!w-[340px]'"
-        />
-        <el-select
-          v-model="filterForm.orderType"
-          clearable
-          placeholder="订单类型"
-          :class="appStore.isPhone ? '!w-full' : appStore.isTablet ? '!w-[150px]' : '!w-[160px]'"
-        >
-          <el-option label="部门单" value="department" />
-          <el-option label="散客单" value="walkin" />
-        </el-select>
-        <div :class="['flex gap-2', appStore.isPhone ? 'w-full' : '']">
-          <el-button :class="appStore.isPhone ? 'flex-1' : ''" type="primary" :loading="pieLoading" @click="handleFilterSearch">
-            查询统计
-          </el-button>
-          <el-button :class="appStore.isPhone ? 'flex-1' : ''" :disabled="pieLoading" @click="handleFilterReset">
-            重置条件
-          </el-button>
+  <div class="grid gap-4 lg:grid-cols-3">
+    <div v-for="card in pieCards" :key="card.key" class="apple-card p-5 sm:p-6">
+      <div class="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 class="text-base font-semibold text-slate-800 dark:text-slate-200">{{ card.title }}</h3>
+          <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">{{ card.description }}</p>
+        </div>
+        <div class="shrink-0 text-right">
+          <div class="text-[11px] text-slate-400 dark:text-slate-500">
+            {{ card.valueType === 'count' ? '总单数' : '总金额' }}
+          </div>
+          <div class="text-xs font-semibold text-slate-600 dark:text-slate-300">
+            {{
+              card.valueType === 'count'
+                ? `${formatCount(getCardTotalValue(card.slices))} 单`
+                : `¥${formatAmount(getCardTotalValue(card.slices))}`
+            }}
+          </div>
         </div>
       </div>
-    </div>
-    <div class="grid gap-4 lg:grid-cols-3">
-      <div v-for="card in pieCards" :key="card.key" class="apple-card p-5 sm:p-6">
-        <div class="mb-4 flex items-start justify-between gap-3">
-          <div>
-            <h3 class="text-base font-semibold text-slate-800 dark:text-slate-200">{{ card.title }}</h3>
-            <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">{{ card.description }}</p>
-          </div>
-          <div class="shrink-0 text-right">
-            <div class="text-[11px] text-slate-400 dark:text-slate-500">
-              {{ card.valueType === 'count' ? '总单数' : '总金额' }}
-            </div>
-            <div class="text-xs font-semibold text-slate-600 dark:text-slate-300">
-              {{
-                card.valueType === 'count'
-                  ? `${formatCount(getCardTotalValue(card.slices))} 单`
-                  : `¥${formatAmount(getCardTotalValue(card.slices))}`
-              }}
+      <div v-if="pieLoading" class="flex min-h-[220px] items-center justify-center">
+        <el-skeleton animated :rows="6" class="w-full" />
+      </div>
+      <div v-else-if="card.slices.length" class="space-y-4">
+        <div class="mx-auto flex w-full max-w-[240px] items-center justify-center">
+          <div class="relative h-44 w-full max-w-[240px]">
+            <BaseEChart :option="buildPieOption(card.slices, card.valueType)" :min-height="176" />
+            <div class="pointer-events-none absolute inset-0 flex items-center justify-center text-center">
+              <el-icon :size="32" class="text-slate-300/80 dark:text-slate-600/80">
+                <component :is="card.valueType === 'count' ? Document : Money" />
+              </el-icon>
             </div>
           </div>
         </div>
-        <div v-if="pieLoading" class="flex min-h-[220px] items-center justify-center">
-          <el-skeleton animated :rows="6" class="w-full" />
-        </div>
-        <div v-else-if="card.slices.length" class="space-y-4">
-          <div class="mx-auto flex w-full max-w-[240px] items-center justify-center">
-            <div class="relative h-44 w-full max-w-[240px]">
-              <BaseEChart :option="buildPieOption(card.slices, card.valueType)" :min-height="176" />
-              <div class="pointer-events-none absolute inset-0 flex items-center justify-center text-center">
-                <el-icon :size="32" class="text-slate-300/80 dark:text-slate-600/80">
-                  <component :is="card.valueType === 'count' ? Document : Money" />
-                </el-icon>
-              </div>
+        <div class="space-y-2">
+          <div v-for="(slice, index) in card.slices" :key="`${card.key}-${slice.key}-${index}`" class="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2 text-xs dark:bg-slate-900/40">
+            <div class="flex min-w-0 items-center gap-2">
+              <span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ backgroundColor: resolvePieLegendColor(index) }" />
+              <span class="truncate text-slate-700 dark:text-slate-200">{{ slice.label }}</span>
+            </div>
+            <div class="shrink-0 text-slate-600 dark:text-slate-300">
+              {{ Number(slice.ratio ?? 0).toFixed(2) }}% ｜ {{ formatSliceValue(slice.value, card.valueType) }}
             </div>
           </div>
-          <div class="space-y-2">
-            <div v-for="(slice, index) in card.slices" :key="`${card.key}-${slice.key}-${index}`" class="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2 text-xs dark:bg-slate-900/40">
-              <div class="flex min-w-0 items-center gap-2">
-                <span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ backgroundColor: resolvePieLegendColor(index) }" />
-                <span class="truncate text-slate-700 dark:text-slate-200">{{ slice.label }}</span>
-              </div>
-              <div class="shrink-0 text-slate-600 dark:text-slate-300">
-                {{ Number(slice.ratio ?? 0).toFixed(2) }}% ｜ {{ formatSliceValue(slice.value, card.valueType) }}
-              </div>
-            </div>
-          </div>
-        </div>
-        <div v-else class="flex min-h-[220px] items-center justify-center rounded-xl bg-slate-50 dark:bg-slate-900/40">
-          <el-empty :image-size="64" :description="card.emptyText" />
         </div>
       </div>
+      <div v-else class="flex min-h-[220px] items-center justify-center rounded-xl bg-slate-50 dark:bg-slate-900/40">
+        <el-empty :image-size="64" :description="card.emptyText" />
+      </div>
     </div>
-  </section>
+  </div>
 </template>

--- a/src/views/dashboard/components/TopCustomerDrilldownDrawer.vue
+++ b/src/views/dashboard/components/TopCustomerDrilldownDrawer.vue
@@ -16,6 +16,7 @@ import dayjs from 'dayjs'
 
 import { BizResponsiveDrawerShell } from '@/components/common'
 import { getCustomerDrilldown, type CustomerDrilldownResult } from '@/api/modules/dashboard'
+import type { DashboardAppliedFilter } from '../composables/useDashboardAnalytics'
 import { useStableRequest } from '@/composables/useStableRequest'
 import { extractErrorMessage } from '@/utils/error'
 
@@ -24,6 +25,8 @@ import { showAppError, showAppWarning } from '@/utils/app-alert'
 const props = defineProps<{
   modelValue: boolean
   customerName: string
+  /** 当前统计区间与订单类型，保证明细口径与榜单一致。 */
+  filter: DashboardAppliedFilter
 }>()
 
 const emit = defineEmits<{
@@ -59,7 +62,15 @@ const loadData = async () => {
   loading.value = true
   data.value = null
   await request.runLatest({
-    executor: (signal) => getCustomerDrilldown(props.customerName, {}, { signal }),
+    executor: (signal) =>
+      getCustomerDrilldown(
+        props.customerName,
+        {
+          dateRange: props.filter.dateRange,
+          orderType: props.filter.orderType || undefined,
+        },
+        { signal },
+      ),
     onSuccess: (result) => {
       data.value = result
     },

--- a/src/views/dashboard/components/TopCustomerRankCard.vue
+++ b/src/views/dashboard/components/TopCustomerRankCard.vue
@@ -7,20 +7,28 @@
  * - 通过轻量交互把首页信息密度控制在可浏览范围内，避免把客户明细全部堆到首屏。
  * 维护说明：
  * - 若后续新增客户排行指标，优先在当前卡片能力上扩展，保持和商品排行卡片一致的使用方式；
+ * - 统计区间由首页筛选栏统一下发，卡片不得写死“本月”之类的口径；
  * - 客户排行的名称、金额和数量口径必须与后端统计定义保持一致，不能在组件内二次解释。
  */
 
 
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import type { DashboardTopCustomer } from '@/api/modules/dashboard'
 import TopCustomerDrilldownDrawer from './TopCustomerDrilldownDrawer.vue'
+import type { DashboardAppliedFilter, DashboardRankOptions } from '../composables/useDashboardAnalytics'
 
 import { showAppWarning } from '@/utils/app-alert'
 
-defineProps<{
+const props = defineProps<{
   topCustomers: DashboardTopCustomer[]
+  options: DashboardRankOptions
+  filter: DashboardAppliedFilter
+  rangeLabel: string
+  loading: boolean
 }>()
+
+const rankSubtitle = computed(() => `按出库金额 Top ${props.options.topN}`)
 
 const drawerVisible = ref(false)
 const activeCustomerName = ref('')
@@ -45,10 +53,16 @@ const openDrilldown = (customerName: string) => {
 <template>
   <div class="apple-card p-5 sm:p-6 xl:p-7">
     <div class="mb-5 flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">经常购买部门榜</h2>
-      <span class="text-xs text-slate-500 dark:text-slate-400">按本月出库金额 Top 5</span>
+      <div class="min-w-0">
+        <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">经常购买部门榜</h2>
+        <p class="mt-1 truncate text-xs text-slate-500 dark:text-slate-400">{{ props.rangeLabel }}</p>
+      </div>
+      <span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">{{ rankSubtitle }}</span>
     </div>
-    <div v-if="topCustomers.length" class="space-y-3">
+    <div v-if="props.loading" class="min-h-[180px]">
+      <el-skeleton animated :rows="5" class="w-full" />
+    </div>
+    <div v-else-if="topCustomers.length" class="space-y-3">
       <button
         v-for="(item, index) in topCustomers"
         :key="`${item.customerName}-${index}`"
@@ -66,8 +80,8 @@ const openDrilldown = (customerName: string) => {
       </button>
     </div>
     <div v-else class="flex min-h-[180px] items-center justify-center rounded-xl bg-slate-50 text-slate-400 dark:bg-slate-900/40">
-      <el-empty :image-size="64" description="暂无榜单数据" />
+      <el-empty :image-size="64" description="所选区间暂无榜单数据" />
     </div>
   </div>
-  <TopCustomerDrilldownDrawer v-model="drawerVisible" :customer-name="activeCustomerName" />
+  <TopCustomerDrilldownDrawer v-model="drawerVisible" :customer-name="activeCustomerName" :filter="props.filter" />
 </template>

--- a/src/views/dashboard/components/TopProductDrilldownDrawer.vue
+++ b/src/views/dashboard/components/TopProductDrilldownDrawer.vue
@@ -7,6 +7,7 @@
  * - 组件内部自行维护打开态监听与请求回写，但继续复用共享稳定请求能力避免旧响应覆盖新选择。
  * 维护说明：
  * - 若后续补充更多钻取字段，优先保持抽屉式延迟加载，不要把重数据回填到排行卡片本体；
+ * - 时间区间与订单类型由首页筛选栏统一下发，抽屉不得自行推断口径，否则明细会和榜单对不上；
  * - 时间维度和统计口径调整时，要同步校验标题、字段标签与接口参数是否仍一致。
  */
 
@@ -16,6 +17,7 @@ import dayjs from 'dayjs'
 
 import { BizResponsiveDrawerShell } from '@/components/common'
 import { getProductDrilldown, type ProductDrilldownResult } from '@/api/modules/dashboard'
+import type { DashboardAppliedFilter } from '../composables/useDashboardAnalytics'
 import { useStableRequest } from '@/composables/useStableRequest'
 import { extractErrorMessage } from '@/utils/error'
 
@@ -24,6 +26,10 @@ import { showAppError, showAppWarning } from '@/utils/app-alert'
 const props = defineProps<{
   modelValue: boolean
   productId: string
+  /** 细分规格模式下只看该名称快照对应的明细；合并模式传空串即看整个商品。 */
+  nameSnapshot: string
+  /** 当前统计区间与订单类型，保证明细口径与榜单一致。 */
+  filter: DashboardAppliedFilter
 }>()
 
 const emit = defineEmits<{
@@ -59,12 +65,21 @@ const loadData = async () => {
   loading.value = true
   data.value = null
   await request.runLatest({
-    executor: (signal) => getProductDrilldown(props.productId, {}, { signal }),
+    executor: (signal) =>
+      getProductDrilldown(
+        props.productId,
+        {
+          nameSnapshot: props.nameSnapshot || undefined,
+          dateRange: props.filter.dateRange,
+          orderType: props.filter.orderType || undefined,
+        },
+        { signal },
+      ),
     onSuccess: (result) => {
       data.value = result
     },
     onError: (error) => {
-      showAppError(extractErrorMessage(error, '获取Top5明细失败'))
+      showAppError(extractErrorMessage(error, '获取商品榜明细失败'))
       emit('update:modelValue', false)
     },
     onFinally: () => {
@@ -74,7 +89,7 @@ const loadData = async () => {
 }
 
 watch(
-  () => [props.modelValue, props.productId] as const,
+  () => [props.modelValue, props.productId, props.nameSnapshot] as const,
   ([visible]) => {
     if (visible) {
       void loadData()

--- a/src/views/dashboard/components/TopProductRankCard.vue
+++ b/src/views/dashboard/components/TopProductRankCard.vue
@@ -14,13 +14,14 @@
  */
 
 
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onDeactivated, ref } from 'vue'
 
 import type { DashboardProductSpecMode, DashboardTopProduct } from '@/api/modules/dashboard'
 import { getProductList, type ProductRecord } from '@/api/modules/product'
 import TopProductDrilldownDrawer from './TopProductDrilldownDrawer.vue'
 import type { DashboardAppliedFilter, DashboardRankOptions } from '../composables/useDashboardAnalytics'
 import { DASHBOARD_TOP_N_OPTIONS } from '../composables/useDashboardAnalytics'
+import { useStableRequest } from '@/composables/useStableRequest'
 import { extractErrorMessage } from '@/utils/error'
 
 import { showAppError, showAppWarning } from '@/utils/app-alert'
@@ -42,6 +43,7 @@ const activeProductId = ref('')
 const activeNameSnapshot = ref('')
 const productOptions = ref<ProductRecord[]>([])
 const productSearching = ref(false)
+const productSearchRequest = useStableRequest()
 
 const isSpecMode = computed(() => props.options.productSpecMode === 'spec')
 
@@ -62,25 +64,47 @@ const formatQty = (value: string | number | null | undefined): string => {
 /**
  * 商品远程检索：
  * - 复用基础资料的商品列表接口，只取启用商品，避免选到停用物料；
- * - 关键字为空时不主动拉全量，由用户输入后再查，降低首页额外请求。
+ * - 关键字为空时不主动拉全量，由用户输入后再查，降低首页额外请求；
+ * - 走 useStableRequest 并透传 signal：连续输入或中途清空时会中止在途请求，
+ *   只允许最后一次结果回写候选列表，避免慢响应盖掉新关键字的结果。
  */
 const handleProductSearch = async (keyword: string) => {
   const normalizedKeyword = keyword.trim()
   if (!normalizedKeyword) {
+    // 清空关键字时同样要中止在途请求，否则它返回后仍会把旧候选写回已清空的下拉。
+    productSearchRequest.cancel()
+    productSearching.value = false
     productOptions.value = []
     return
   }
 
   productSearching.value = true
-  try {
-    productOptions.value = await getProductList({ keyword: normalizedKeyword, isActive: true })
-  } catch (error) {
-    showAppError(extractErrorMessage(error, '检索商品失败'))
-    productOptions.value = []
-  } finally {
-    productSearching.value = false
-  }
+  await productSearchRequest.runLatest({
+    executor: (signal) => getProductList({ keyword: normalizedKeyword, isActive: true }, { signal }),
+    onSuccess: (result) => {
+      productOptions.value = result
+    },
+    onError: (error) => {
+      showAppError(extractErrorMessage(error, '检索商品失败'))
+      productOptions.value = []
+    },
+    onFinally: () => {
+      productSearching.value = false
+    },
+  })
 }
+
+/**
+ * 失活与卸载时复位检索加载态：
+ * - useStableRequest 的 cancel() 会把 activeController 置空，runLatest 随后判定请求已过期直接返回，
+ *   onFinally 不会被调用；不复位的话下拉会永远停在“加载中”。
+ */
+const resetSearchingOnLeave = () => {
+  productSearching.value = false
+}
+
+onDeactivated(resetSearchingOnLeave)
+onBeforeUnmount(resetSearchingOnLeave)
 
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
 const handleSpecModeChange = (value: boolean) => {

--- a/src/views/dashboard/components/TopProductRankCard.vue
+++ b/src/views/dashboard/components/TopProductRankCard.vue
@@ -1,73 +1,191 @@
 <script setup lang="ts">
 /**
  * 模块说明：src/views/dashboard/components/TopProductRankCard.vue
- * 文件职责：负责仪表盘热销商品排行卡片展示，并提供进入商品明细抽屉的交互入口。
+ * 文件职责：负责仪表盘热销商品排行卡片展示，提供“合并/细分规格”切换、指定商品筛选与 Top N 选择，并承接钻取入口。
  * 实现逻辑：
- * - 组件承接排行列表的轻量展示，真正的明细查询延后到抽屉打开时再触发；
- * - 卡片层只做排行项选中和提示反馈，不把钻取查询提前塞进首页首屏。
+ * - 卡片层只做维度选择与排行项选中，真正的聚合查询由上层 useDashboardAnalytics 统一发起，避免首页出现多套口径；
+ * - 默认按商品合并：同一商品的不同颜色/款式合并数量后参与排序，榜单只展示商品名称；
+ * - 打开“细分规格”后按具体款式分别统计与排序，并用标签明确展示规格文本；
+ * - 榜单行 key 与钻取入参统一使用后端下发的 rankKey，因为细分模式下同一 productId 会出现多行。
  * 维护说明：
  * - 若后续扩展更多排行维度，优先在卡片配置层补齐，不要复制一份新的排行组件；
- * - 商品排行文案和排序口径必须与后端统计接口保持一致，避免运营解读偏差。
+ * - 商品排行文案和排序口径必须与后端统计接口保持一致（当前为出库数量），避免运营解读偏差；
+ * - 规格文本来源于出库明细的商品名称快照，手工开单不含规格，统一显示为“默认规格”，改动前请先确认数据来源。
  */
 
 
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-import type { DashboardTopProduct } from '@/api/modules/dashboard'
+import type { DashboardProductSpecMode, DashboardTopProduct } from '@/api/modules/dashboard'
+import { getProductList, type ProductRecord } from '@/api/modules/product'
 import TopProductDrilldownDrawer from './TopProductDrilldownDrawer.vue'
+import type { DashboardAppliedFilter, DashboardRankOptions } from '../composables/useDashboardAnalytics'
+import { DASHBOARD_TOP_N_OPTIONS } from '../composables/useDashboardAnalytics'
+import { extractErrorMessage } from '@/utils/error'
 
-import { showAppWarning } from '@/utils/app-alert'
+import { showAppError, showAppWarning } from '@/utils/app-alert'
 
-defineProps<{
+const props = defineProps<{
   topProducts: DashboardTopProduct[]
+  options: DashboardRankOptions
+  filter: DashboardAppliedFilter
+  rangeLabel: string
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:options', value: Partial<DashboardRankOptions>): void
 }>()
 
 const drawerVisible = ref(false)
 const activeProductId = ref('')
+const activeNameSnapshot = ref('')
+const productOptions = ref<ProductRecord[]>([])
+const productSearching = ref(false)
+
+const isSpecMode = computed(() => props.options.productSpecMode === 'spec')
+
+const rankSubtitle = computed(() => {
+  const dimension = isSpecMode.value ? '按规格' : '按商品'
+  return `${dimension}出库数量 Top ${props.options.topN}`
+})
+
+const emptyDescription = computed(() => {
+  return props.options.productId ? '所选商品在该区间暂无出库' : '所选区间暂无榜单数据'
+})
 
 const formatQty = (value: string | number | null | undefined): string => {
   const normalizedNumber = Number(value ?? 0)
   return Number.isFinite(normalizedNumber) ? normalizedNumber.toFixed(2) : '0.00'
 }
 
+/**
+ * 商品远程检索：
+ * - 复用基础资料的商品列表接口，只取启用商品，避免选到停用物料；
+ * - 关键字为空时不主动拉全量，由用户输入后再查，降低首页额外请求。
+ */
+const handleProductSearch = async (keyword: string) => {
+  const normalizedKeyword = keyword.trim()
+  if (!normalizedKeyword) {
+    productOptions.value = []
+    return
+  }
+
+  productSearching.value = true
+  try {
+    productOptions.value = await getProductList({ keyword: normalizedKeyword, isActive: true })
+  } catch (error) {
+    showAppError(extractErrorMessage(error, '检索商品失败'))
+    productOptions.value = []
+  } finally {
+    productSearching.value = false
+  }
+}
+
 // 详细注释：此处承接当前模块的关键状态、流程或结构定义。
-const openDrilldown = (productId: string) => {
-  if (!productId.trim()) {
+const handleSpecModeChange = (value: boolean) => {
+  const productSpecMode: DashboardProductSpecMode = value ? 'spec' : 'merged'
+  emit('update:options', { productSpecMode })
+}
+
+const handleProductChange = (value: string | null) => {
+  emit('update:options', { productId: value ?? '' })
+}
+
+const handleTopNChange = (value: number) => {
+  emit('update:options', { topN: value })
+}
+
+// 详细注释：此处承接当前模块的关键状态、流程或结构定义。
+const openDrilldown = (item: DashboardTopProduct) => {
+  if (!item.productId.trim()) {
     showAppWarning('当前榜单项缺少产品标识')
     return
   }
 
-  activeProductId.value = productId
+  activeProductId.value = item.productId
+  // 合并模式看整个商品的明细，细分模式只看该规格对应的名称快照。
+  activeNameSnapshot.value = item.nameSnapshot ?? ''
   drawerVisible.value = true
 }
 </script>
 
 <template>
   <div class="apple-card p-5 sm:p-6 xl:p-7">
-    <div class="mb-5 flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">热门出库文创榜</h2>
-      <span class="text-xs text-slate-500 dark:text-slate-400">按本月出库数量 Top 5</span>
+    <div class="mb-4 flex flex-wrap items-start justify-between gap-2">
+      <div class="min-w-0">
+        <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">热门出库文创榜</h2>
+        <p class="mt-1 truncate text-xs text-slate-500 dark:text-slate-400">{{ props.rangeLabel }}</p>
+      </div>
+      <span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">{{ rankSubtitle }}</span>
     </div>
-    <div v-if="topProducts.length" class="space-y-3">
+
+    <div class="mb-4 flex flex-wrap items-center gap-2">
+      <el-select
+        :model-value="props.options.productId || null"
+        class="!w-full sm:!w-[200px]"
+        clearable
+        filterable
+        remote
+        reserve-keyword
+        :remote-method="handleProductSearch"
+        :loading="productSearching"
+        placeholder="全部商品（可搜索指定商品）"
+        @update:model-value="handleProductChange($event as string | null)"
+      >
+        <el-option v-for="product in productOptions" :key="product.id" :label="product.productName" :value="product.id" />
+      </el-select>
+
+      <el-select
+        :model-value="props.options.topN"
+        class="!w-[104px]"
+        @update:model-value="handleTopNChange($event as number)"
+      >
+        <el-option v-for="topN in DASHBOARD_TOP_N_OPTIONS" :key="topN" :label="`Top ${topN}`" :value="topN" />
+      </el-select>
+
+      <div class="flex items-center gap-2">
+        <el-switch
+          :model-value="isSpecMode"
+          @update:model-value="handleSpecModeChange($event as boolean)"
+        />
+        <span class="text-xs text-slate-500 dark:text-slate-400">细分规格</span>
+      </div>
+    </div>
+
+    <div v-if="props.loading" class="min-h-[180px]">
+      <el-skeleton animated :rows="5" class="w-full" />
+    </div>
+    <div v-else-if="topProducts.length" class="space-y-3">
       <button
         v-for="(item, index) in topProducts"
-        :key="`${item.productId}-${index}`"
+        :key="item.rankKey"
         type="button"
-        class="flex w-full items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5 text-left transition hover:bg-slate-100 dark:bg-slate-900/40 dark:hover:bg-slate-900/60"
-        @click="openDrilldown(item.productId)"
+        class="flex w-full items-center justify-between gap-3 rounded-xl bg-slate-50 px-3 py-2.5 text-left transition hover:bg-slate-100 dark:bg-slate-900/40 dark:hover:bg-slate-900/60"
+        @click="openDrilldown(item)"
       >
         <div class="flex min-w-0 items-center gap-3">
-          <div class="flex h-7 w-7 items-center justify-center rounded-full bg-brand/10 text-xs font-bold text-brand dark:bg-brand/20 dark:text-teal-400">
+          <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand/10 text-xs font-bold text-brand dark:bg-brand/20 dark:text-teal-400">
             {{ index + 1 }}
           </div>
-          <div class="truncate text-sm font-medium text-slate-700 dark:text-slate-200">{{ item.productName }}</div>
+          <div class="min-w-0">
+            <div class="truncate text-sm font-medium text-slate-700 dark:text-slate-200">{{ item.productName }}</div>
+            <el-tag v-if="item.specLabel" size="small" effect="plain" class="mt-1 !px-1.5">
+              {{ item.specLabel }}
+            </el-tag>
+          </div>
         </div>
-        <div class="text-sm font-semibold text-slate-700 dark:text-slate-200">{{ formatQty(item.totalQty) }} 件</div>
+        <div class="shrink-0 text-sm font-semibold text-slate-700 dark:text-slate-200">{{ formatQty(item.totalQty) }} 件</div>
       </button>
     </div>
     <div v-else class="flex min-h-[180px] items-center justify-center rounded-xl bg-slate-50 text-slate-400 dark:bg-slate-900/40">
-      <el-empty :image-size="64" description="暂无榜单数据" />
+      <el-empty :image-size="64" :description="emptyDescription" />
     </div>
   </div>
-  <TopProductDrilldownDrawer v-model="drawerVisible" :product-id="activeProductId" />
+  <TopProductDrilldownDrawer
+    v-model="drawerVisible"
+    :product-id="activeProductId"
+    :name-snapshot="activeNameSnapshot"
+    :filter="props.filter"
+  />
 </template>

--- a/src/views/dashboard/components/TopProductRankCard.vue
+++ b/src/views/dashboard/components/TopProductRankCard.vue
@@ -63,7 +63,10 @@ const formatQty = (value: string | number | null | undefined): string => {
 
 /**
  * 商品远程检索：
- * - 复用基础资料的商品列表接口，只取启用商品，避免选到停用物料；
+ * - 复用基础资料的商品列表接口；
+ * - 不过滤启停状态：这里是历史报表的筛选维度，商品出库后被停用，其历史明细仍会被区间分析统计到，
+ *   若只查启用商品，用户就再也无法在下拉里找到它做跨年或规格对比。停用只应阻止新业务使用商品，
+ *   不该把它从历史报表里抹掉；候选项会为停用商品打上标记，避免误以为它还能开单；
  * - 关键字为空时不主动拉全量，由用户输入后再查，降低首页额外请求；
  * - 走 useStableRequest 并透传 signal：连续输入或中途清空时会中止在途请求，
  *   只允许最后一次结果回写候选列表，避免慢响应盖掉新关键字的结果。
@@ -80,7 +83,7 @@ const handleProductSearch = async (keyword: string) => {
 
   productSearching.value = true
   await productSearchRequest.runLatest({
-    executor: (signal) => getProductList({ keyword: normalizedKeyword, isActive: true }, { signal }),
+    executor: (signal) => getProductList({ keyword: normalizedKeyword }, { signal }),
     onSuccess: (result) => {
       productOptions.value = result
     },
@@ -157,7 +160,14 @@ const openDrilldown = (item: DashboardTopProduct) => {
         placeholder="全部商品（可搜索指定商品）"
         @update:model-value="handleProductChange($event as string | null)"
       >
-        <el-option v-for="product in productOptions" :key="product.id" :label="product.productName" :value="product.id" />
+        <el-option v-for="product in productOptions" :key="product.id" :label="product.productName" :value="product.id">
+          <span class="flex items-center justify-between gap-2">
+            <span class="truncate">{{ product.productName }}</span>
+            <el-tag v-if="!product.isActive" size="small" type="info" effect="plain" class="shrink-0 !px-1.5">
+              已停用
+            </el-tag>
+          </span>
+        </el-option>
       </el-select>
 
       <el-select

--- a/src/views/dashboard/components/TrendChartCard.vue
+++ b/src/views/dashboard/components/TrendChartCard.vue
@@ -3,9 +3,10 @@
  * 模块说明：src/views/dashboard/components/TrendChartCard.vue
  * 文件职责：负责仪表盘趋势图卡片的图表配置组装与主题适配，展示订单、金额等时间序列趋势。
  * 实现逻辑：
- * - 组件接收上层整理后的趋势点数据，只在本地完成 ECharts option 计算与视觉呈现；
+ * - 组件接收上层整理后的趋势点数据与统计区间文案，只在本地完成 ECharts option 计算与视觉呈现；
  * - 图表颜色和辅助线样式跟随主题状态切换，避免深浅主题下出现可读性下降。
  * 维护说明：
+ * - 趋势的时间区间与分桶粒度由首页筛选栏统一决定，组件内不得再写死“近 7 日”之类的口径；
  * - 若后续新增趋势维度，优先扩展数据映射与图例配置，不要把接口请求下沉到图表组件内部；
  * - 图表交互应保持克制，避免悬浮态和动画过重影响首页首屏响应。
  */
@@ -21,7 +22,14 @@ import { escapeTooltipHtml } from '@/utils/html-escape'
 
 const props = defineProps<{
   trend: DashboardTrendPoint[]
+  /** 当前统计区间文案，由上层筛选栏统一下发，避免图表标题写死“近 7 日”。 */
+  rangeLabel: string
+  /** 趋势分桶粒度文案：按日 / 按月。 */
+  granularityLabel: string
+  loading: boolean
 }>()
+
+const trendTitle = computed(() => `出库趋势（${props.granularityLabel}）`)
 const themeStore = useThemeStore(pinia)
 
 const formatAmount = (value: string | number | null | undefined): string => {
@@ -148,18 +156,25 @@ const trendOption = computed<EChartsOption>(() => ({
 <template>
   <div class="apple-card p-5 sm:p-6 xl:p-7">
     <div class="mb-5 flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">近 7 日出库趋势</h2>
-      <div class="text-xs text-slate-500 dark:text-slate-400">
+      <div class="min-w-0">
+        <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">{{ trendTitle }}</h2>
+        <p class="mt-1 truncate text-xs text-slate-500 dark:text-slate-400">{{ props.rangeLabel }}</p>
+      </div>
+      <div class="shrink-0 text-xs text-slate-500 dark:text-slate-400">
         峰值：<span class="font-semibold text-slate-700 dark:text-slate-200">¥{{ peakAmount }}</span>
       </div>
     </div>
 
-    <div v-if="props.trend.length > 1">
+    <div v-if="props.loading" class="flex min-h-[260px] items-center justify-center">
+      <el-skeleton animated :rows="7" class="w-full" />
+    </div>
+
+    <div v-else-if="props.trend.length > 1">
       <BaseEChart :option="trendOption" :min-height="260" />
     </div>
 
     <div v-else class="flex min-h-[260px] items-center justify-center rounded-xl bg-slate-50 text-slate-400 dark:bg-slate-900/40">
-      <el-empty :image-size="72" description="暂无趋势数据" />
+      <el-empty :image-size="72" description="所选区间暂无趋势数据" />
     </div>
   </div>
 </template>

--- a/src/views/dashboard/composables/useDashboardAnalytics.ts
+++ b/src/views/dashboard/composables/useDashboardAnalytics.ts
@@ -1,0 +1,228 @@
+/**
+ * 模块说明：`src/views/dashboard/composables/useDashboardAnalytics.ts`
+ * 文件职责：收敛工作台首页“统计区间 + 榜单维度”筛选状态，并统一驱动趋势图与两个排行榜的数据加载。
+ * 实现逻辑：
+ * - 区间条件分为草稿态与已应用态：草稿只跟随控件变化，点击“查询统计”或“重置条件”后才提交，避免拖动日期时反复打接口；
+ * - 榜单维度（规格模式 / 指定商品 / Top N）属于即时生效项，变更后直接重新加载，符合“切一下就看结果”的使用直觉；
+ * - 按月模式下把 YYYY-MM 展开为当月首日与当月末日，保证跨月跨年区间完整覆盖首月与末月；
+ * - 请求竞态交给 useStableRequest 的 runLatest 处理，不再使用 `if (loading) return` 这类早退守卫，
+ *   否则用户快速切换筛选时新请求会被直接吞掉，反而更容易看到过期结果。
+ * 维护说明：
+ * - 饼图、趋势图、榜单必须共用这里的 appliedFilter，任何一处单独维护区间都会导致首页出现两套口径；
+ * - 新增筛选维度时优先在本文件扩展，不要把请求逻辑下沉到图表或榜单组件内部。
+ */
+
+import { computed, reactive, ref } from 'vue'
+import dayjs from 'dayjs'
+
+import {
+  getDashboardAnalytics,
+  type DashboardAnalyticsResult,
+  type DashboardProductSpecMode,
+  type DashboardTopCustomer,
+  type DashboardTopProduct,
+  type DashboardTrendGranularity,
+  type DashboardTrendPoint,
+} from '@/api/modules/dashboard'
+import { useStableRequest } from '@/composables/useStableRequest'
+import { extractErrorMessage } from '@/utils/error'
+import { showAppError } from '@/utils/app-alert'
+
+export type DashboardOrderTypeFilter = '' | 'department' | 'walkin'
+
+/** 已应用的统计区间：饼图、趋势图、榜单与下钻抽屉共用同一份口径。 */
+export interface DashboardAppliedFilter {
+  granularity: DashboardTrendGranularity
+  /** 展开后的实际起止日期（YYYY-MM-DD），为空表示交由后端回落到本月。 */
+  dateRange: [string, string] | null
+  orderType: DashboardOrderTypeFilter
+}
+
+/** 榜单维度选项，变更后立即重新加载。 */
+export interface DashboardRankOptions {
+  productSpecMode: DashboardProductSpecMode
+  productId: string
+  topN: number
+}
+
+export const DASHBOARD_TOP_N_OPTIONS = [5, 10, 20] as const
+
+/**
+ * 把控件值展开为实际统计日期：
+ * - 按日模式直接透传 YYYY-MM-DD；
+ * - 按月模式把 YYYY-MM 展开为当月首日 / 当月末日，确保末月整月都被统计进来。
+ */
+const expandRangeValue = (
+  granularity: DashboardTrendGranularity,
+  rawRange: [string, string] | [],
+): [string, string] | null => {
+  if (rawRange.length !== 2) {
+    return null
+  }
+
+  const [rawStart, rawEnd] = rawRange
+  if (!rawStart || !rawEnd) {
+    return null
+  }
+
+  if (granularity === 'day') {
+    return [rawStart, rawEnd]
+  }
+
+  const startMonth = dayjs(rawStart)
+  const endMonth = dayjs(rawEnd)
+  if (!startMonth.isValid() || !endMonth.isValid()) {
+    return null
+  }
+
+  return [startMonth.startOf('month').format('YYYY-MM-DD'), endMonth.endOf('month').format('YYYY-MM-DD')]
+}
+
+// 详细注释：此处承接当前模块的关键状态、流程或结构定义。
+export const useDashboardAnalytics = () => {
+  const analyticsRequest = useStableRequest()
+  const analyticsLoading = ref(false)
+  const trend = ref<DashboardTrendPoint[]>([])
+  const topProducts = ref<DashboardTopProduct[]>([])
+  const topCustomers = ref<DashboardTopCustomer[]>([])
+  /** 后端回执的真实生效区间，用于标题与“当前统计区间”文案，避免前端自说自话。 */
+  const resolvedRange = ref<DashboardAnalyticsResult['range'] | null>(null)
+
+  // 草稿态：只跟随筛选控件，点击查询/重置后才提交到 appliedFilter。
+  const draftFilter = reactive({
+    granularity: 'day' as DashboardTrendGranularity,
+    rangeValue: [] as [string, string] | [],
+    orderType: '' as DashboardOrderTypeFilter,
+  })
+
+  const appliedFilter = ref<DashboardAppliedFilter>({
+    granularity: 'day',
+    dateRange: null,
+    orderType: '',
+  })
+
+  const rankOptions = reactive<DashboardRankOptions>({
+    productSpecMode: 'merged',
+    productId: '',
+    topN: DASHBOARD_TOP_N_OPTIONS[0],
+  })
+
+  /** 当前统计区间文案：区间未知时不编造“本月”，等后端回执再展示。 */
+  const rangeLabel = computed(() => {
+    const range = resolvedRange.value
+    if (!range?.startDate || !range?.endDate) {
+      return '统计区间加载中'
+    }
+    return `${range.startDate} 至 ${range.endDate}`
+  })
+
+  const granularityLabel = computed(() => (resolvedRange.value?.granularity === 'month' ? '按月' : '按日'))
+
+  const orderTypeLabel = computed(() => {
+    if (appliedFilter.value.orderType === 'department') {
+      return '部门单'
+    }
+    if (appliedFilter.value.orderType === 'walkin') {
+      return '散客单'
+    }
+    return '全部订单类型'
+  })
+
+  /** 下钻抽屉复用的筛选条件，保证明细口径与榜单一致。 */
+  const drilldownFilter = computed(() => ({
+    dateRange: appliedFilter.value.dateRange,
+    orderType: appliedFilter.value.orderType || undefined,
+  }))
+
+  const loadAnalytics = async () => {
+    analyticsLoading.value = true
+    await analyticsRequest.runLatest({
+      executor: (signal) =>
+        getDashboardAnalytics(
+          {
+            dateRange: appliedFilter.value.dateRange,
+            orderType: appliedFilter.value.orderType || undefined,
+            granularity: appliedFilter.value.granularity,
+            productSpecMode: rankOptions.productSpecMode,
+            productId: rankOptions.productId || undefined,
+            topN: rankOptions.topN,
+          },
+          { signal },
+        ),
+      onSuccess: (result) => {
+        trend.value = result.trend ?? []
+        topProducts.value = result.topProducts ?? []
+        topCustomers.value = result.topCustomers ?? []
+        resolvedRange.value = result.range
+      },
+      onError: (error) => {
+        showAppError(extractErrorMessage(error, '获取区间统计失败'))
+      },
+      onFinally: ({ status }) => {
+        // 请求被新筛选中止时不要提前收起加载态，否则会闪出一次空态。
+        if (status !== 'canceled') {
+          analyticsLoading.value = false
+        }
+      },
+    })
+  }
+
+  /** 提交草稿区间：切换粒度时清空已选值，避免把月份值当日期发给后端。 */
+  const applyDraftFilter = () => {
+    appliedFilter.value = {
+      granularity: draftFilter.granularity,
+      dateRange: expandRangeValue(draftFilter.granularity, draftFilter.rangeValue),
+      orderType: draftFilter.orderType,
+    }
+  }
+
+  const handleGranularityChange = () => {
+    draftFilter.rangeValue = []
+  }
+
+  const handleSearch = () => {
+    applyDraftFilter()
+    void loadAnalytics()
+  }
+
+  const handleReset = () => {
+    draftFilter.granularity = 'day'
+    draftFilter.rangeValue = []
+    draftFilter.orderType = ''
+    applyDraftFilter()
+    void loadAnalytics()
+  }
+
+  const handleRankOptionsChange = (next: Partial<DashboardRankOptions>) => {
+    if (next.productSpecMode) {
+      rankOptions.productSpecMode = next.productSpecMode
+    }
+    if (typeof next.productId === 'string') {
+      rankOptions.productId = next.productId
+    }
+    if (next.topN) {
+      rankOptions.topN = next.topN
+    }
+    void loadAnalytics()
+  }
+
+  return {
+    analyticsLoading,
+    trend,
+    topProducts,
+    topCustomers,
+    resolvedRange,
+    draftFilter,
+    appliedFilter,
+    rankOptions,
+    rangeLabel,
+    granularityLabel,
+    orderTypeLabel,
+    drilldownFilter,
+    loadAnalytics,
+    handleGranularityChange,
+    handleSearch,
+    handleReset,
+    handleRankOptionsChange,
+  }
+}

--- a/src/views/dashboard/composables/useDashboardAnalytics.ts
+++ b/src/views/dashboard/composables/useDashboardAnalytics.ts
@@ -12,7 +12,7 @@
  * - 新增筛选维度时优先在本文件扩展，不要把请求逻辑下沉到图表或榜单组件内部。
  */
 
-import { computed, reactive, ref } from 'vue'
+import { computed, onBeforeUnmount, onDeactivated, reactive, ref } from 'vue'
 import dayjs from 'dayjs'
 
 import {
@@ -87,6 +87,8 @@ export const useDashboardAnalytics = () => {
   const topCustomers = ref<DashboardTopCustomer[]>([])
   /** 后端回执的真实生效区间，用于标题与“当前统计区间”文案，避免前端自说自话。 */
   const resolvedRange = ref<DashboardAnalyticsResult['range'] | null>(null)
+  /** 最近一次区间查询的错误文案：非空时页面不得继续展示上一次的成功结果。 */
+  const analyticsError = ref('')
 
   // 草稿态：只跟随筛选控件，点击查询/重置后才提交到 appliedFilter。
   const draftFilter = reactive({
@@ -107,13 +109,21 @@ export const useDashboardAnalytics = () => {
     topN: DASHBOARD_TOP_N_OPTIONS[0],
   })
 
-  /** 当前统计区间文案：区间未知时不编造“本月”，等后端回执再展示。 */
+  /**
+   * 当前统计区间文案：
+   * - 优先用后端回执，未知时不编造“本月”；
+   * - 查询失败后回执会被清空，此时退回展示用户实际提交的区间，避免文案与错误提示互相矛盾。
+   */
   const rangeLabel = computed(() => {
     const range = resolvedRange.value
-    if (!range?.startDate || !range?.endDate) {
-      return '统计区间加载中'
+    if (range?.startDate && range?.endDate) {
+      return `${range.startDate} 至 ${range.endDate}`
     }
-    return `${range.startDate} 至 ${range.endDate}`
+    const requestedRange = appliedFilter.value.dateRange
+    if (requestedRange) {
+      return `${requestedRange[0]} 至 ${requestedRange[1]}`
+    }
+    return '统计区间加载中'
   })
 
   const granularityLabel = computed(() => (resolvedRange.value?.granularity === 'month' ? '按月' : '按日'))
@@ -136,6 +146,7 @@ export const useDashboardAnalytics = () => {
 
   const loadAnalytics = async () => {
     analyticsLoading.value = true
+    analyticsError.value = ''
     await analyticsRequest.runLatest({
       executor: (signal) =>
         getDashboardAnalytics(
@@ -150,19 +161,26 @@ export const useDashboardAnalytics = () => {
           { signal },
         ),
       onSuccess: (result) => {
+        analyticsError.value = ''
         trend.value = result.trend ?? []
         topProducts.value = result.topProducts ?? []
         topCustomers.value = result.topCustomers ?? []
         resolvedRange.value = result.range
       },
       onError: (error) => {
-        showAppError(extractErrorMessage(error, '获取区间统计失败'))
+        // appliedFilter 已经切到新条件，若继续留着上一次的成功结果，
+        // 用户会把旧统计当成新筛选的结果读。因此失败时一并清空数据与区间回执，
+        // 由错误文案接管展示，绝不让旧数字配新标签。
+        const message = extractErrorMessage(error, '获取区间统计失败')
+        analyticsError.value = message
+        trend.value = []
+        topProducts.value = []
+        topCustomers.value = []
+        resolvedRange.value = null
+        showAppError(message)
       },
-      onFinally: ({ status }) => {
-        // 请求被新筛选中止时不要提前收起加载态，否则会闪出一次空态。
-        if (status !== 'canceled') {
-          analyticsLoading.value = false
-        }
+      onFinally: () => {
+        analyticsLoading.value = false
       },
     })
   }
@@ -193,6 +211,20 @@ export const useDashboardAnalytics = () => {
     void loadAnalytics()
   }
 
+  /**
+   * 失活与卸载时复位加载态：
+   * - useStableRequest 的 cancel() 会把 activeController 置空，runLatest 的收尾逻辑
+   *   随后判定“当前请求已过期”而直接返回，onFinally 根本不会被调用；
+   * - 若不在这里复位，keep-alive 页面在请求未完成时离开，analyticsLoading 会永久为 true，
+   *   重新进入时 ensureDashboardReady 又因加载态为真而拒绝重试，图表会永远停在骨架屏。
+   */
+  const resetLoadingOnLeave = () => {
+    analyticsLoading.value = false
+  }
+
+  onDeactivated(resetLoadingOnLeave)
+  onBeforeUnmount(resetLoadingOnLeave)
+
   const handleRankOptionsChange = (next: Partial<DashboardRankOptions>) => {
     if (next.productSpecMode) {
       rankOptions.productSpecMode = next.productSpecMode
@@ -208,6 +240,7 @@ export const useDashboardAnalytics = () => {
 
   return {
     analyticsLoading,
+    analyticsError,
     trend,
     topProducts,
     topCustomers,

--- a/src/views/dashboard/composables/useDashboardAnalytics.ts
+++ b/src/views/dashboard/composables/useDashboardAnalytics.ts
@@ -89,6 +89,14 @@ export const useDashboardAnalytics = () => {
   const resolvedRange = ref<DashboardAnalyticsResult['range'] | null>(null)
   /** 最近一次区间查询的错误文案：非空时页面不得继续展示上一次的成功结果。 */
   const analyticsError = ref('')
+  /**
+   * 当前展示数据对应的筛选条件签名：
+   * - 只有请求成功回写时才更新，因此可以判断“手上这份数据是不是当前条件的结果”；
+   * - 不能用“有没有数据”当重入门禁：用户提交新区间后若在请求完成前离开 keep-alive 页面，
+   *   请求会被取消，但 appliedFilter 已经是新条件，而榜单与趋势仍是旧条件的结果；
+   *   再次进入时若因“已有数据”跳过重试，点击旧榜单行却会用新区间下钻，口径就对不上了。
+   */
+  const loadedFilterSignature = ref('')
 
   // 草稿态：只跟随筛选控件，点击查询/重置后才提交到 appliedFilter。
   const draftFilter = reactive({
@@ -138,6 +146,19 @@ export const useDashboardAnalytics = () => {
     return '全部订单类型'
   })
 
+  const buildFilterSignature = () =>
+    JSON.stringify({
+      granularity: appliedFilter.value.granularity,
+      dateRange: appliedFilter.value.dateRange,
+      orderType: appliedFilter.value.orderType,
+      productSpecMode: rankOptions.productSpecMode,
+      productId: rankOptions.productId,
+      topN: rankOptions.topN,
+    })
+
+  /** 手上的数据是否已经跟不上当前筛选条件（含首次加载与被取消的请求）。 */
+  const isAnalyticsStale = computed(() => loadedFilterSignature.value !== buildFilterSignature())
+
   /** 下钻抽屉复用的筛选条件，保证明细口径与榜单一致。 */
   const drilldownFilter = computed(() => ({
     dateRange: appliedFilter.value.dateRange,
@@ -145,6 +166,8 @@ export const useDashboardAnalytics = () => {
   }))
 
   const loadAnalytics = async () => {
+    // 在发起请求时就固定签名：请求期间用户可能又改了条件，回写时必须对应本次真正请求的那一组。
+    const requestSignature = buildFilterSignature()
     analyticsLoading.value = true
     analyticsError.value = ''
     await analyticsRequest.runLatest({
@@ -162,6 +185,7 @@ export const useDashboardAnalytics = () => {
         ),
       onSuccess: (result) => {
         analyticsError.value = ''
+        loadedFilterSignature.value = requestSignature
         trend.value = result.trend ?? []
         topProducts.value = result.topProducts ?? []
         topCustomers.value = result.topCustomers ?? []
@@ -173,6 +197,7 @@ export const useDashboardAnalytics = () => {
         // 由错误文案接管展示，绝不让旧数字配新标签。
         const message = extractErrorMessage(error, '获取区间统计失败')
         analyticsError.value = message
+        loadedFilterSignature.value = ''
         trend.value = []
         topProducts.value = []
         topCustomers.value = []
@@ -225,6 +250,17 @@ export const useDashboardAnalytics = () => {
   onDeactivated(resetLoadingOnLeave)
   onBeforeUnmount(resetLoadingOnLeave)
 
+  /**
+   * 页面首次挂载与 keep-alive 重新激活时的兜底：
+   * - 以“数据是否对应当前筛选条件”为准，而不是“有没有数据”；
+   * - 这样被取消的新筛选请求在重新进入时一定会补跑，榜单与下钻不会停留在两套区间上。
+   */
+  const ensureAnalyticsReady = () => {
+    if (isAnalyticsStale.value && !analyticsLoading.value) {
+      void loadAnalytics()
+    }
+  }
+
   const handleRankOptionsChange = (next: Partial<DashboardRankOptions>) => {
     if (next.productSpecMode) {
       rankOptions.productSpecMode = next.productSpecMode
@@ -241,6 +277,8 @@ export const useDashboardAnalytics = () => {
   return {
     analyticsLoading,
     analyticsError,
+    isAnalyticsStale,
+    ensureAnalyticsReady,
     trend,
     topProducts,
     topCustomers,


### PR DESCRIPTION
## 问题与结果

Closes #60。

首页只有「结构占比」饼图有区间筛选，趋势图与两个榜单由 `/dashboard/stats` 提供，区间在后端硬编码为「本月」且只有下界没有上界，前端文案也写死「按本月出库数量 Top 5」，无法做年末、学期这类跨月跨年报告。同时商品榜把同一商品的不同颜色拆成多行。

拆行的根因不是「没做合并」，而是分组多了一列：榜单 SQL 按 `item.productId` **加** `item.productNameSnapshot` 双字段分组，而 O2O 预订核销转出库时把规格拼进了名称快照（`商品名（规格）`，`o2o-preorder.service.ts`），手工开单只写商品名（`order.service.ts`）。

本 PR 把首页「结构占比」区块内的筛选栏升级为唯一区间入口，同时驱动三个饼图、趋势图与两个榜单；商品榜改为默认按商品合并、可切换细分规格并锁定单个商品做款式对比。四宫格（今日/本月）与近期动态（审计事件流）维持原口径不变。

## 主要变更

**后端**

- 新增 `GET /dashboard/analytics`（`dashboard:view`），统一提供区间趋势、热门商品榜、部门榜，支持 `startDate`/`endDate`、`orderType`、`granularity`、`productSpecMode`、`productId`、`topN`，并回执真实生效区间供前端展示。
- 商品榜合并模式只按 `productId` 分组、名称取商品主表；细分模式追加名称快照分组，规格文本由名称快照解析。两种模式的 Top N 都在 SQL 聚合完成之后才截断，因此合并数量恒等于该商品全部规格数量之和。合并模式下非分组列包在 `MAX()` 里，兼容 MySQL 8 的 `ONLY_FULL_GROUP_BY`。
- 结构占比饼图的商品维度改为按商品合并，不再因规格裂成多片；分片截断到 Top 8 后补一片「其他」。
- 区间校验补齐：起止必须成对、开始不得晚于结束、格式必须为 `YYYY-MM-DD`、区间上限 366 天，全部返回 400 与明确文案。
- `/dashboard/stats` 瘦身为四宫格 + 近期动态，接口签名与前端调用方式保持不变。
- 商品下钻新增 `nameSnapshot` 参数，细分模式下只看该规格的明细。
- 修复趋势分桶两处既有缺陷：桶键由 UTC 日期改为本地日期（容器时区 +08 时，凌晨 00:00–08:00 的单据原本被算到前一天）；趋势查询由 `getRawMany` 改为 `getMany`，原始结果会跳过驱动的时间归一化，SQLite 返回的无时区 UTC 字符串会被重新按本地时间解析，导致整段趋势串日。任意区间下这两个偏差都会被放大，因此一并修掉。

**前端**

- 新增 `useDashboardAnalytics` 收敛区间草稿态/已应用态与榜单维度：区间改动点「查询统计」后生效，榜单维度即时生效。
- 新增 `DashboardFilterBar`：按日/按月双模式区间选择，按月模式展开为首月 1 日至末月最后一日，完整覆盖首末月；栏内展示后端回执的真实生效区间。
- 商品榜新增细分规格开关、指定商品远程检索（复用 `getProductList`）、Top N（5/10/20）切换；行 key 与下钻入参改用后端下发的 `rankKey` / `nameSnapshot`。
- 两个下钻抽屉透传当前区间与订单类型，明细口径与榜单一致。
- 移除饼图与工作台的 `if (loading) return` 早退守卫，竞态交回 `useStableRequest` 的 `runLatest`，否则快速切换筛选时新请求会被吞掉。

**顺带修复的两条既有门禁**（均在 main 上就已失败，与本功能无关，详见 #60 的分析评论）

- `task345:verify` 断言写死 `/getProductDetail\(row\.id\)/`，而 `ProductManager.vue` 后来接入 `useStableRequest` 改为 `getProductDetail(row.id, { signal })`。已确认源码没有退化（`src` 下 12 处以上同形态调用，`verify-enterprise-core-paths.mjs` 更是强制要求透传 signal），断言更新为与 core-paths 同口径的写法，同时补上对 signal 透传的保护。
- `verify:performance:budget` 总产物超预算。逐提交测量定位到越界点为 #57（4181.62 KB → 4203.13 KB，该 PR 的提交信息自己就写明「性能门禁未通过」），此后漂移到 4214.68 KB。`src/components/charts/echarts.ts` 注册了 `LegendComponent` 与 `GraphicComponent`，但全仓库 ECharts option 里 `legend`、`graphic` 一次都没用到（饼图图例是自绘 HTML）。移除后 charting 分包 530.81 KB → 500.90 KB，总产物 4194.14 KB，门禁恢复通过。**未调整预算数值。**

## 验证

- `npm --prefix backend run build`
- `npm --prefix backend run dashboard:analytics:verify`（本 PR 新增，9 组断言，已接入 `verify-unit-functional-suite`）
- `npm --prefix backend run task345:verify`
- `npm --prefix backend run task8:verify`
- `npm --prefix backend run task2:route-contract:verify`
- `npm --prefix backend run security:business-boundary:verify`
- `npm run build`
- `npm run verify:performance:budget`（通过，总产物 4194.14 / 4200 KB）
- `npm run verify:performance:core-paths`
- `npm run verify:text-encoding`

新增回归脚本覆盖：跨年区间 2025-12-01 ~ 2026-08-31 的边界包含、合并数量等于各规格之和、先完整聚合再截断 Top N、指定商品筛选与规格模式组合、非法 Top N 兜底、趋势按月连续补零与本地时区分桶、空区间返回空榜单、四类非法入参各返回 400、饼图「其他」分片使总额与占比口径一致、下钻继承区间与规格、概览接口瘦身。

未通过且已确认为既有问题（在 main 上同样复现，与本 PR 无关）：`npm --prefix backend run release:verify` 的客户端注册返回 409「当前注册信息无法使用，请确认联系方式已完成验证后重试」，疑似脚本未适配注册前置的联系方式验证要求。

## 影响与回滚

**两处需要运营知晓的口径变化**

1. 饼图默认区间：原来不传区间等于统计**全部历史**，现在与榜单一致回落到**本月**。标签聚合等旧调用方保持原有「不传即全量」语义不变。
2. 饼图占比分母：原来是 Top 8 之和，现在是区间全量总额，被截断的部分汇总为「其他」。这样卡片「总金额」才等于区间真实总额、各分片占比之和才是 100%。

**已知口径限制**

`biz_outbound_order_item` 没有 `sku_id` 也没有 `spec_text_snapshot`，规格只存在于 `product_name_snapshot` 字符串里。因此「细分规格」只对 O2O 核销生成的出库单有效；手工开单写入的是不含规格的商品名，在细分模式下统一归为「默认规格」。要让手工开单也带规格，需要给出库明细补 SKU 关联并改开单链路，即 #68 的范围，本 PR 不做该数据库迁移。

**其他**

- 无数据库迁移，无新增依赖，无部署配置变更。
- 包体门禁虽已恢复通过，但余量很薄（总产物余 5.86 KB、首屏 CSS 余 6.91 KB），后续功能仍可能顶红；真正的大头是 pdf-export 914 KB、ui-kit 579.56 KB、charting 500.90 KB、qr-scanner 360.44 KB 四个低频重包，建议另开 issue 单独治理。
- 回滚：回退本分支的三个提交即可，其中 `5e40a18`（ECharts 减包）与 `d138637`（断言修正）可独立保留。
