### PR TITLE
fix(o2o): 预订单商品明细补充下单时的款式与规格展示

### DIFF
--- a/docs/project-context/32-O2O 预订单、核销、退货与正式出库联动.md
+++ b/docs/project-context/32-O2O 预订单、核销、退货与正式出库联动.md
@@ -52,6 +52,12 @@
   - `preOrderedStock`：预订单占用库存
 - 预订单核心状态：`pending`、`verified`、`cancelled`，并叠加 `businessStatus`、`statusReport`。
 - 价格快照采用 `originalPrice`、`discountRate`、`discountedPrice`、`unitPrice`、`lineAmount`，避免实时产品价格污染历史订单。
+- 规格快照采用 `skuCodeSnapshot`、`specTextSnapshot`、`skuImageSnapshot`，退货明细同样继承下单时的规格快照。
+- 明细行的规格展示口径统一收口在 `src/utils/o2o-item-spec.ts`，由 `BizO2oItemSpecText` 组件渲染：
+  - 真实规格正常展示；`默认规格` 属单规格商品，不再渲染标签；
+  - 规格文本缺失但仍有 SKU 编码时展示编码兜底；SKU 化改造前的历史订单显式提示“未记录规格”；
+  - 任何情况下都不得回查当前商品 SKU 补全，避免商品改名、改规格或下架后污染历史订单展示。
+- 出库单商品名快照由后端 `createOutboundOrderFromPreorder()` 拼成 `商品名（规格）`，客户端出库单预览用 `buildO2oItemDisplayName()` 保持同口径。
 - 预订单核销成功后会生成正式出库单，并用特定 `idempotencyKey` 前缀与出库单建立联动。
 - 退货核销是否回现货库存，取决于原订单在退货时的来源状态。
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "verify:product-sku-matrix": "node ./scripts/verify-product-sku-matrix.mjs",
     "verify:product-sku-layout": "node ./scripts/verify-product-sku-layout.mjs",
     "verify:o2o-sku-editor": "node ./scripts/verify-o2o-sku-editor.mjs",
+    "verify:o2o-order-item-spec": "node ./scripts/verify-o2o-order-item-spec.mjs",
     "verify:image-upload-compression": "node ./scripts/verify-image-upload-compression.mjs",
     "verify:mall-catalog-performance": "node ./scripts/verify-mall-catalog-performance.mjs",
     "verify:o2o:public-read-cache": "node ./scripts/verify-o2o-public-read-cache.mjs",

--- a/scripts/verify-o2o-order-item-spec-current.ts
+++ b/scripts/verify-o2o-order-item-spec-current.ts
@@ -1,0 +1,119 @@
+/**
+ * 模块说明：scripts/verify-o2o-order-item-spec-current.ts
+ * 文件职责：守护 O2O 预订单/退货明细的“下单时款式与规格”展示口径（issue #62）。
+ * 实现逻辑：
+ * - 单元断言 resolveO2oItemSpecView() 对四种数据形态的判定，防止默认规格与历史缺失被混为一谈；
+ * - 断言 buildO2oItemDisplayName() 与后端出库单 productNameSnapshot 拼接口径一致；
+ * - 静态断言客户端与管理端各查看入口确实接入了规格副行组件，防止后续改版把展示悄悄改回去。
+ */
+
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import {
+  O2O_DEFAULT_SPEC_TEXT,
+  O2O_MISSING_SPEC_TEXT,
+  buildO2oItemDisplayName,
+  resolveO2oItemSpecView,
+} from '../src/utils/o2o-item-spec'
+
+const helperPath = path.resolve('src/utils/o2o-item-spec.ts')
+const specComponentPath = path.resolve('src/components/common/business-composite/BizO2oItemSpecText.vue')
+
+assert.equal(
+  existsSync(helperPath),
+  true,
+  'O2O 明细规格展示口径必须集中在 src/utils/o2o-item-spec.ts，避免各页面各写一套判定',
+)
+assert.equal(
+  existsSync(specComponentPath),
+  true,
+  '规格副行必须由共享组件统一渲染，避免客户端与管理端出现不一致的展示结论',
+)
+
+// 1. 真实规格：正常展示下单时选中的款式。
+assert.deepEqual(
+  resolveO2oItemSpecView({ skuId: 'sku-1', skuCode: 'P001-RED-S', specText: '红色 / S' }),
+  { visible: true, text: '红色 / S', kind: 'spec' },
+  '有真实规格快照时必须原样展示，保证同名商品的不同款式可区分',
+)
+
+// 2. 默认规格：单规格商品不再渲染无信息量的标签。
+assert.deepEqual(
+  resolveO2oItemSpecView({ skuId: 'sku-2', skuCode: 'P002-DEFAULT', specText: O2O_DEFAULT_SPEC_TEXT }),
+  { visible: false, text: O2O_DEFAULT_SPEC_TEXT, kind: 'default' },
+  '默认规格属于单规格商品，不应在明细行渲染额外标签',
+)
+
+// 3. 规格文本缺失但仍绑定 SKU：用下单时的 SKU 编码兜底，保留追溯线索。
+assert.deepEqual(
+  resolveO2oItemSpecView({ skuId: 'sku-3', skuCode: 'P003-BLUE-M', specText: null }),
+  { visible: true, text: '规格编码 P003-BLUE-M', kind: 'spec' },
+  '规格文本缺失但存在 SKU 编码时，应展示编码而不是留空',
+)
+
+// 4. SKU 化改造前的历史订单：显式提示未记录，不允许猜测或用当前商品规格冒充。
+assert.deepEqual(
+  resolveO2oItemSpecView({ skuId: null, skuCode: null, specText: null }),
+  { visible: true, text: O2O_MISSING_SPEC_TEXT, kind: 'missing' },
+  '历史订单缺少规格快照时必须显式提示，且不得回查当前商品规格补全',
+)
+
+assert.deepEqual(
+  resolveO2oItemSpecView({ skuId: null, skuCode: '  ', specText: '   ' }),
+  { visible: true, text: O2O_MISSING_SPEC_TEXT, kind: 'missing' },
+  '全空白快照应与缺失同等处理，避免渲染出空白占位',
+)
+
+// 出库单商品名：与后端 createOutboundOrderFromPreorder() 的 productNameSnapshot 口径逐字一致。
+assert.equal(
+  buildO2oItemDisplayName('运动鞋', { specText: '红色 / 42' }),
+  '运动鞋（红色 / 42）',
+  '出库单预览的商品名必须带上下单规格，与核销后落库的快照保持一致',
+)
+assert.equal(
+  buildO2oItemDisplayName('运动鞋', { specText: O2O_DEFAULT_SPEC_TEXT }),
+  `运动鞋（${O2O_DEFAULT_SPEC_TEXT}）`,
+  '后端对默认规格同样会拼接规格文本，出库单预览不得擅自省略',
+)
+assert.equal(
+  buildO2oItemDisplayName('运动鞋', { specText: null }),
+  '运动鞋',
+  '没有规格快照的历史订单，出库单商品名保持原样，不补任何括号',
+)
+
+// 静态守护：各查看入口必须实际接入规格副行组件。
+const countSpecUsage = (relativePath: string) => {
+  const absolutePath = path.resolve(relativePath)
+  assert.equal(existsSync(absolutePath), true, `${relativePath} 不存在，无法校验规格展示接入情况`)
+  return readFileSync(absolutePath, 'utf8').split('<BizO2oItemSpecText').length - 1
+}
+
+const clientDetailPath = 'src/views/client/ClientOrderDetailView.vue'
+assert.equal(
+  countSpecUsage(clientDetailPath),
+  2,
+  `${clientDetailPath} 的预订明细表与退货明细表都必须展示下单规格`,
+)
+assert.equal(
+  readFileSync(path.resolve(clientDetailPath), 'utf8').includes('buildO2oItemDisplayName(item.productName, item)'),
+  true,
+  `${clientDetailPath} 的出库单预览必须与后端商品名快照同口径拼接规格`,
+)
+
+const orderQueryPath = 'src/views/o2o/O2oOrderQueryView.vue'
+assert.equal(
+  countSpecUsage(orderQueryPath),
+  3,
+  `${orderQueryPath} 的桌面表格、移动端卡片与退货商品都必须展示下单规格`,
+)
+
+const verifyConsolePath = 'src/views/o2o/O2oVerifyConsoleView.vue'
+assert.equal(
+  countSpecUsage(verifyConsolePath),
+  2,
+  `${verifyConsolePath} 的预订明细表与退货明细表都必须展示下单规格`,
+)
+
+console.log('✅ O2O 预订单明细规格展示口径校验通过')

--- a/scripts/verify-o2o-order-item-spec.mjs
+++ b/scripts/verify-o2o-order-item-spec.mjs
@@ -1,0 +1,28 @@
+/**
+ * 模块说明：scripts/verify-o2o-order-item-spec.mjs
+ * 文件职责：以仓库统一方式驱动 O2O 明细规格展示口径校验（issue #62）。
+ * 实现逻辑：复用 backend 内置的 tsx CLI 执行 TypeScript 校验脚本，避免为验证单独引入新依赖。
+ */
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const tsxCliPath = path.join(projectRoot, 'backend', 'node_modules', 'tsx', 'dist', 'cli.mjs')
+const verifyScriptPath = path.join(projectRoot, 'scripts', 'verify-o2o-order-item-spec-current.ts')
+
+const result = spawnSync(
+  process.execPath,
+  [tsxCliPath, '--tsconfig', path.join(projectRoot, 'tsconfig.app.json'), verifyScriptPath],
+  {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+    },
+  },
+)
+
+process.exit(result.status ?? 1)

--- a/scripts/verify-unit-functional-suite.mjs
+++ b/scripts/verify-unit-functional-suite.mjs
@@ -64,6 +64,16 @@ const main = async () => {
     projectRoot,
   )
 
+  // O2O 明细规格展示口径门禁：
+  // - 校验预订单/退货明细在客户端与管理端各查看入口都展示下单时的款式规格（issue #62）；
+  // - 防止后续改版把规格副行删掉，让同名商品的不同款式重新变得无法区分。
+  await runStep(
+    'O2O 明细规格展示口径检查',
+    process.execPath,
+    [path.join(projectRoot, 'scripts', 'verify-o2o-order-item-spec.mjs')],
+    projectRoot,
+  )
+
   // 后端类型校验作为功能脚本执行前的门禁，避免编译层问题掩盖业务问题。
   await runNpmScript('后端类型校验', 'check', backendRoot)
 

--- a/src/components/common/business-composite/BizO2oItemSpecText.vue
+++ b/src/components/common/business-composite/BizO2oItemSpecText.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+/**
+ * 模块说明：src/components/common/business-composite/BizO2oItemSpecText.vue
+ * 文件职责：统一渲染 O2O 预订单、退货单明细行的“下单时款式/规格”副行。
+ * 实现逻辑：
+ * - 只负责规格副行本身，商品名仍由各页面按既有排版渲染，避免接入后改变原有视觉；
+ * - 展示口径全部下沉到 src/utils/o2o-item-spec.ts，保证客户端与管理端各查看入口结论一致；
+ * - 单规格商品不渲染任何内容，历史缺失规格用更淡的斜体文案显式提示，二者不混淆。
+ */
+
+import { computed } from 'vue'
+
+import { resolveO2oItemSpecView, type O2oItemSpecSource } from '@/utils/o2o-item-spec'
+
+/**
+ * 明细行规格参数：
+ * - item 直接传订单/退货明细行本身，组件只读取其中的下单快照字段。
+ */
+interface Props {
+  item: O2oItemSpecSource
+}
+
+const props = defineProps<Props>()
+
+const specView = computed(() => resolveO2oItemSpecView(props.item))
+</script>
+
+<template>
+  <p
+    v-if="specView.visible"
+    class="mt-1 break-words text-xs leading-5"
+    :class="specView.kind === 'missing' ? 'italic text-slate-400' : 'text-slate-500'"
+  >
+    {{ specView.text }}
+  </p>
+</template>

--- a/src/components/common/business-composite/index.ts
+++ b/src/components/common/business-composite/index.ts
@@ -13,5 +13,6 @@
  * - 页面统一从该入口接入组合能力，避免再次回到扁平文件直引。
  */
 export { default as BizCrudDialogShell } from './BizCrudDialogShell.vue'
+export { default as BizO2oItemSpecText } from './BizO2oItemSpecText.vue'
 export { default as BizResponsiveDataCollectionShell } from './BizResponsiveDataCollectionShell.vue'
 export { default as BizResponsiveDrawerShell } from './BizResponsiveDrawerShell.vue'

--- a/src/utils/o2o-item-spec.ts
+++ b/src/utils/o2o-item-spec.ts
@@ -1,0 +1,79 @@
+/**
+ * 模块说明：src/utils/o2o-item-spec.ts
+ * 文件职责：统一 O2O 预订单、退货单明细行的“下单时款式/规格”展示口径。
+ * 实现逻辑：
+ * - 只读取订单行上的下单快照（specText / skuCode），绝不回查当前商品的 SKU 去补全，
+ *   避免商品事后改名、改规格或下架后，把历史订单渲染成另一个款式；
+ * - 真实规格正常展示；「默认规格」属于单规格商品，不再重复渲染无信息量的标签；
+ * - 快照缺失的历史订单显式提示“未记录规格”，与“商品本来就没有规格”区分开，
+ *   杜绝 undefined、空白占位以及用当前规格冒充历史规格。
+ * 维护说明：
+ * - 后端快照写入位于 backend/src/services/o2o-preorder.service.ts 的 buildPreorderSkuItemSnapshot()，
+ *   新单的 specText 至少为「默认规格」，因此下方缺失分支只会命中 SKU 化改造前的历史数据；
+ * - 正式出库单的商品名拼接口径由后端 createOutboundOrderFromPreorder() 决定，
+ *   调整 buildO2oItemDisplayName() 时必须同步核对两端，保证预览与打印逐字一致。
+ */
+
+/** 后端对单规格商品写入的规格快照文本，见 buildPreorderSkuItemSnapshot()。 */
+export const O2O_DEFAULT_SPEC_TEXT = '默认规格'
+
+/** 快照缺失时的兜底文案，用于提示历史订单没有留下规格记录。 */
+export const O2O_MISSING_SPEC_TEXT = '未记录规格'
+
+export interface O2oItemSpecSource {
+  skuId?: string | number | null
+  skuCode?: string | null
+  specText?: string | null
+}
+
+export interface O2oItemSpecView {
+  /** 是否需要在明细行渲染规格文本；单规格商品为 false。 */
+  visible: boolean
+  /** 展示文案。 */
+  text: string
+  /**
+   * 语义分类：
+   * - spec：下单时选中的真实规格，或可溯源的 SKU 编码；
+   * - default：单规格商品的默认规格，无需展示；
+   * - missing：历史订单没有留下规格快照。
+   */
+  kind: 'spec' | 'default' | 'missing'
+}
+
+const normalizeSnapshotText = (value: string | number | null | undefined): string => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  return String(value).trim()
+}
+
+/**
+ * 按下单快照解析明细行的规格展示视图。
+ * 判定顺序刻意从“信息最完整”走到“信息最缺失”，保证同一条数据在各查看入口得到一致结论。
+ */
+export const resolveO2oItemSpecView = (source: O2oItemSpecSource): O2oItemSpecView => {
+  const specText = normalizeSnapshotText(source.specText)
+  if (specText && specText !== O2O_DEFAULT_SPEC_TEXT) {
+    return { visible: true, text: specText, kind: 'spec' }
+  }
+  if (specText === O2O_DEFAULT_SPEC_TEXT) {
+    return { visible: false, text: O2O_DEFAULT_SPEC_TEXT, kind: 'default' }
+  }
+  // 规格文本缺失但仍绑定了 SKU 时，用下单时的 SKU 编码兜底，至少保留可追溯线索。
+  const skuCode = normalizeSnapshotText(source.skuCode)
+  if (skuCode) {
+    return { visible: true, text: `规格编码 ${skuCode}`, kind: 'spec' }
+  }
+  return { visible: true, text: O2O_MISSING_SPEC_TEXT, kind: 'missing' }
+}
+
+/**
+ * 拼接正式出库单模板使用的商品名。
+ * 这里刻意与页面展示口径不同：只要下单快照存在规格文本就拼接（含「默认规格」），
+ * 从而与后端核销时落库的 productNameSnapshot 逐字一致，避免核销前预览与核销后打印对不上。
+ */
+export const buildO2oItemDisplayName = (productName: string, source: O2oItemSpecSource): string => {
+  const normalizedProductName = normalizeSnapshotText(productName)
+  const specText = normalizeSnapshotText(source.specText)
+  return specText ? `${normalizedProductName}（${specText}）` : normalizedProductName
+}

--- a/src/views/client/ClientOrderDetailView.vue
+++ b/src/views/client/ClientOrderDetailView.vue
@@ -27,7 +27,7 @@ import {
   type O2oReturnRequestDetail,
 } from '@/api/modules/o2o'
 import type { OrderDetailResult } from '@/api/modules/order'
-import { BaseRequestState } from '@/components/common'
+import { BaseRequestState, BizO2oItemSpecText } from '@/components/common'
 import { useStableRequest } from '@/composables/useStableRequest'
 import {
   CLIENT_O2O_ORDER_STATUS_LABEL_MAP,
@@ -48,6 +48,7 @@ import { showCriticalErrorDialog } from '@/utils/error-dialog'
 import ClientOrderEditDialog from '@/views/client/components/ClientOrderEditDialog.vue'
 import ClientOrderReturnDialog from '@/views/client/components/ClientOrderReturnDialog.vue'
 import { showAppError, showAppInfo, showAppSuccess, showAppWarning } from '@/utils/app-alert'
+import { buildO2oItemDisplayName } from '@/utils/o2o-item-spec'
 import { normalizeDiscountRateText, resolveO2oPriceView, type O2oPriceSource } from '@/utils/o2o-price'
 import {
   DEFAULT_VOUCHER_ORIENTATION,
@@ -355,7 +356,8 @@ const voucherOrder = computed<OrderDetailResult | null>(() => {
         id: item.id,
         productId: item.productId,
         productCode: item.productCode,
-        productName: item.productName,
+        // 正式出库单落库的商品名带下单规格，这里同口径拼接，避免核销前预览与核销后打印对不上。
+        productName: buildO2oItemDisplayName(item.productName, item),
         qty: String(item.qty),
         unitPrice,
         subTotal,
@@ -1660,7 +1662,10 @@ onBeforeUnmount(() => {
               </thead>
               <tbody class="divide-y divide-slate-100 bg-white text-slate-700">
                 <tr v-for="item in detail.items" :key="item.id">
-                  <td class="px-4 py-3">{{ item.productName }}</td>
+                  <td class="px-4 py-3">
+                    <p class="break-words">{{ item.productName }}</p>
+                    <BizO2oItemSpecText :item="item" />
+                  </td>
                   <td class="px-4 py-3 text-right">
                     <p class="font-semibold text-teal-600">¥{{ resolveDiscountedUnitPrice(item) }}</p>
                     <p v-if="shouldShowDiscountMeta(item)" class="text-xs text-slate-400">
@@ -1753,7 +1758,10 @@ onBeforeUnmount(() => {
                       </thead>
                       <tbody class="divide-y divide-slate-100 text-slate-700">
                         <tr v-for="item in request.items" :key="item.id">
-                          <td class="px-4 py-3">{{ item.productName }}</td>
+                          <td class="px-4 py-3">
+                            <p class="break-words">{{ item.productName }}</p>
+                            <BizO2oItemSpecText :item="item" />
+                          </td>
                           <td class="px-4 py-3 text-right font-medium">{{ item.qty }}</td>
                         </tr>
                       </tbody>

--- a/src/views/o2o/O2oOrderQueryView.vue
+++ b/src/views/o2o/O2oOrderQueryView.vue
@@ -10,7 +10,7 @@
 import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, reactive, ref, watch } from 'vue'
 import { ElMessageBox } from 'element-plus'
 import { useRouter } from 'vue-router'
-import { PageContainer } from '@/components/common'
+import { BizO2oItemSpecText, PageContainer } from '@/components/common'
 import { usePermissionAction } from '@/composables/usePermissionAction'
 import { useStableRequest } from '@/composables/useStableRequest'
 import {
@@ -1916,6 +1916,7 @@ onBeforeUnmount(() => {
                     >
                       <div class="min-w-0">
                         <p class="break-words text-sm font-semibold text-slate-900">{{ item.productName }}</p>
+                        <BizO2oItemSpecText :item="item" />
                         <p class="mt-1 text-xs text-slate-400">{{ item.productCode }}</p>
                       </div>
                       <p class="shrink-0 text-sm font-semibold text-slate-700">x {{ item.qty }}</p>
@@ -1938,7 +1939,12 @@ onBeforeUnmount(() => {
             <div class="hidden sm:block">
               <div class="table-scroll-wrap">
                 <el-table native-scrollbar :data="activeOrderDetail.items" row-key="id" :loading="detailLoading">
-                  <el-table-column prop="productName" label="商品名称" min-width="180" />
+                  <el-table-column prop="productName" label="商品名称" min-width="180">
+                    <template #default="{ row }">
+                      <p class="break-words">{{ row.productName }}</p>
+                      <BizO2oItemSpecText :item="row" />
+                    </template>
+                  </el-table-column>
                   <el-table-column prop="defaultPrice" label="单价" width="120">
                     <template #default="{ row }">
                       <span>¥{{ formatCurrency(row.defaultPrice) }}</span>
@@ -1960,6 +1966,7 @@ onBeforeUnmount(() => {
                 class="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3"
               >
                 <p class="break-words text-sm font-semibold text-slate-900">{{ item.productName }}</p>
+                <BizO2oItemSpecText :item="item" />
                 <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-slate-500">
                   <p>单价：¥{{ formatCurrency(item.defaultPrice) }}</p>
                   <p class="text-right">数量：{{ item.qty }}</p>

--- a/src/views/o2o/O2oVerifyConsoleView.vue
+++ b/src/views/o2o/O2oVerifyConsoleView.vue
@@ -17,7 +17,7 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { ElMessageBox } from 'element-plus'
 import { useRoute } from 'vue-router'
 import { CameraFilled, DocumentCopy, Search } from '@element-plus/icons-vue'
-import { BizCrudDialogShell, PageContainer, PassiveNumberInput, UnifiedScanDialog } from '@/components/common'
+import { BizCrudDialogShell, BizO2oItemSpecText, PageContainer, PassiveNumberInput, UnifiedScanDialog } from '@/components/common'
 import { useStableRequest } from '@/composables/useStableRequest'
 import {
   VERIFY_CONSOLE_O2O_ORDER_STATUS_CLASS_MAP,
@@ -998,7 +998,12 @@ watch(
 
           <template v-if="preorderDetail">
             <el-table native-scrollbar class="mt-4" :data="preorderDetail.items" row-key="id">
-              <el-table-column prop="productName" label="商品名称" min-width="180" />
+              <el-table-column prop="productName" label="商品名称" min-width="180">
+                <template #default="{ row }">
+                  <p class="break-words">{{ row.productName }}</p>
+                  <BizO2oItemSpecText :item="row" />
+                </template>
+              </el-table-column>
               <el-table-column prop="productCode" label="商品编码" min-width="140" />
               <el-table-column prop="defaultPrice" label="单价" width="120">
                 <template #default="{ row }">
@@ -1059,7 +1064,12 @@ watch(
             </div>
 
             <el-table native-scrollbar class="mt-4" :data="returnRequestDetail.items" row-key="id">
-              <el-table-column prop="productName" label="商品名称" min-width="180" />
+              <el-table-column prop="productName" label="商品名称" min-width="180">
+                <template #default="{ row }">
+                  <p class="break-words">{{ row.productName }}</p>
+                  <BizO2oItemSpecText :item="row" />
+                </template>
+              </el-table-column>
               <el-table-column prop="productCode" label="商品编码" min-width="140" />
               <el-table-column prop="qty" label="退货数量" width="110" align="right" />
             </el-table>


### PR DESCRIPTION
Closes #62

## 背景

用户反馈线上预订单看不到商品的具体款式。预订单详情的「商品明细」只渲染商品名、单价、数量和小计，同一商品的不同颜色/款式在页面上表现为多行重复商品名，无法区分，影响查看订单、备货与核对。

## 根因

**问题出在页面渲染，数据链路本身是完整的**，因此本 PR **不改后端、实体、接口与类型**。

| 层 | 现状 |
| --- | --- |
| 落库 | `o2o_preorder_item` 已保存 `sku_code_snapshot` / `spec_text_snapshot` / `sku_image_snapshot` |
| 服务 | `o2o-preorder.service.ts` 已把 `skuCode`、`specText` 返回给订单详情与退货详情 |
| 类型 | `O2oPreorderDetailItem`、`O2oReturnRequestItem` 已定义对应字段，管理端与客户端共用 |
| 页面 | ❌ 模板从未渲染这些字段 |

改单弹层、退货弹层和核销台的扫码结果区此前已正确展示规格，可作为样式基准；本次把其余入口补齐。

## 展示口径

一律以**下单时的快照**为准，**不回查当前商品 SKU 补全**——避免商品事后改名、改规格或下架后，把历史订单渲染成另一个款式。

| 数据形态 | 判定 | 展示 |
| --- | --- | --- |
| `specText` 有值且非「默认规格」 | 真实规格 | 正常展示规格文字 |
| `specText === '默认规格'` | 单规格商品 | 不渲染标签，避免无信息量的占位 |
| `specText` 为空但 `skuCode` 有值 | 快照残缺、SKU 可溯 | 展示「规格编码 XXX」 |
| `specText` 与 `skuCode` 均为空 | SKU 化改造前的历史单 | 展示「未记录规格」（淡色斜体） |

后端下单路径保证新单 `specText` 至少为「默认规格」，故后两行只会命中历史数据。这样「商品本来就没有规格」与「历史记录丢了规格」在页面上是可区分的，对应 issue 验收标准第 4 条。

## 改动

**新增展示口径真源** `src/utils/o2o-item-spec.ts`
- `resolveO2oItemSpecView()` 收口上表判定，供各页面复用，避免 6 处各写一套；
- `buildO2oItemDisplayName()` 与后端出库单 `productNameSnapshot` 同口径拼接商品名。

**新增共享组件** `BizO2oItemSpecText.vue`
- 只渲染规格副行，商品名仍由各页面按既有排版渲染，接入后各处视觉无回归。

**补齐 6 处查看入口**

| 文件 | 位置 |
| --- | --- |
| `src/views/client/ClientOrderDetailView.vue` | 预订明细表（issue 直接病灶）、退货记录明细表 |
| `src/views/o2o/O2oOrderQueryView.vue` | 桌面表格、移动端卡片、退货商品 |
| `src/views/o2o/O2oVerifyConsoleView.vue` | 预订明细表、退货明细表 |

**顺带修掉一个口径不一致**

客户端出库单预览原先用裸商品名，而核销后后端落库的是 `商品名（规格）`，导致核销前预览与核销后打印的单据对不上。现改用 `buildO2oItemDisplayName()` 对齐。

## 影响面

| 项 | 是否改变 |
| --- | --- |
| 订单主状态 / 商家补充状态 | 否 |
| 金额、数量计算 | 否 |
| 库存占用与释放逻辑 | 否 |
| 核销、退货行为 | 否 |
| 审计逻辑 | 否 |
| 后端 / 实体 / 接口 / 类型 | 否 |
| 客户端与管理端文案 | 仅新增规格副行 |

## 验证

新增 `npm run verify:o2o-order-item-spec`：单元断言四种数据形态的判定，并静态断言 6 处接入点确实引用了规格组件，防止后续改版把规格副行悄悄删掉。已纳入 `verify:unit:functional` 套件。

| 验证 | 结果 |
| --- | --- |
| `verify:o2o-order-item-spec` | 通过 |
| `vue-tsc --noEmit` | 通过，0 报错 |
| `npm run build` | 通过 |
| `verify:text-encoding` | 通过 |
| 后端 `o2o:verify` | 通过（24 项全过） |

**本地联调实测**：用一张含「红色 / S ×2、蓝色 / M ×1、水杯默认规格 ×3」的订单，以及一张抹除了规格快照的模拟历史订单，逐一核对客户端订单详情、管理端订单查询与核销台——同名商品的不同规格可区分，单规格商品无多余标签，历史单显示「未记录规格」，各入口展示一致。

按仓库规范，本次属展示层修复而非核心链路重构，未触发强制 `verify:performance`。

## 文档

同步更新 `docs/project-context/32-O2O 预订单、核销、退货与正式出库联动.md` 的快照与展示口径段落。
