### PR TITLE
fix(reports): 统一库存预览与 Excel 导出的 SKU 汇总口径

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -78,6 +78,7 @@
     "sqlite:legacy-upgrade:verify": "tsx scripts/sqlite-legacy-schema-upgrade-verify.ts",
     "order-query:baseline:verify": "tsx scripts/order-query-baseline-verify.ts",
     "reports:contract:verify": "tsx scripts/report-center-contract-verify.ts",
+    "reports:inventory:verify": "tsx scripts/report-inventory-verify.ts",
     "uploads:legacy:inspect": "tsx scripts/inspect-legacy-upload-urls.ts"
   },
   "dependencies": {

--- a/backend/scripts/report-inventory-verify.ts
+++ b/backend/scripts/report-inventory-verify.ts
@@ -1,0 +1,575 @@
+/**
+ * 模块说明：backend/scripts/report-inventory-verify.ts
+ * 文件职责：使用隔离 SQLite 验证商品服务、库存报表预览和真实 Excel 的库存汇总口径一致。
+ * 实现逻辑：
+ * - 手工固定商品主表与 SKU 差异夹具，覆盖当前、停用、退役和无当前 SKU 的回退语义；
+ * - 调用真实 ProductService、ReportService，并解析流式生成的 ExcelJS 工作簿；
+ * - 对三个出口逐项核对固定期望，同时确认报表读取不会修改库存或库存流水。
+ * 维护说明：
+ * - 夹具期望必须独立手工给出，不能从任一被测出口反推；
+ * - 脚本只能连接本次唯一临时 SQLite，禁止读取或修改业务数据库。
+ */
+
+import 'reflect-metadata'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { Writable } from 'node:stream'
+import { fileURLToPath } from 'node:url'
+import ExcelJS from 'exceljs'
+import type { AuthUserContext } from '../src/types/auth.js'
+import type { ClientAuthContext } from '../src/types/client-auth.js'
+import type { ReportQueryInput, ReportType } from '../src/services/report.service.js'
+
+const backendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const sqliteRoot = path.resolve(backendRoot, 'data', 'local-dev')
+const verifySeed = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`
+const sqlitePath = path.resolve(sqliteRoot, `report-inventory-${verifySeed}.sqlite`)
+
+process.env.APP_PROFILE = `report-inventory-${verifySeed}`
+process.env.DB_TYPE = 'sqlite'
+process.env.DB_SYNC = 'false'
+process.env.SQLITE_DB_PATH = sqlitePath
+process.env.INIT_ADMIN_PASSWORD = `Admin_${verifySeed}_Aa1!`
+
+type StockTriple = readonly [currentStock: number, preOrderedStock: number, availableStock: number]
+
+type FixtureInput = {
+  code: string
+  name: string
+  mainStock: StockTriple
+  skus: Array<{
+    suffix: string
+    currentStock: number
+    preOrderedStock: number
+    isActive: boolean
+    isCurrent: boolean
+  }>
+  expected: StockTriple
+}
+
+const fixtures: FixtureInput[] = [
+  {
+    code: 'REPORT-DEFAULT',
+    name: '默认规格差额商品',
+    mainStock: [90, 40, 50],
+    skus: [{ suffix: 'DEFAULT', currentStock: 8, preOrderedStock: 3, isActive: true, isCurrent: true }],
+    expected: [8, 3, 5],
+  },
+  {
+    code: 'REPORT-MULTI',
+    name: '多规格占用商品',
+    mainStock: [100, 60, 40],
+    skus: [
+      { suffix: 'A', currentStock: 7, preOrderedStock: 2, isActive: true, isCurrent: true },
+      { suffix: 'B', currentStock: 4, preOrderedStock: 1, isActive: true, isCurrent: true },
+    ],
+    expected: [11, 3, 8],
+  },
+  {
+    code: 'REPORT-ZERO',
+    name: '零库存商品',
+    mainStock: [12, 5, 7],
+    skus: [{ suffix: 'ZERO', currentStock: 0, preOrderedStock: 0, isActive: true, isCurrent: true }],
+    expected: [0, 0, 0],
+  },
+  {
+    code: 'REPORT-INACTIVE',
+    name: '当前规格全停用商品',
+    mainStock: [14, 4, 10],
+    skus: [{ suffix: 'OFF', currentStock: 14, preOrderedStock: 4, isActive: false, isCurrent: true }],
+    expected: [0, 0, 0],
+  },
+  {
+    code: 'REPORT-HISTORY',
+    name: '仅历史规格商品',
+    mainStock: [9, 1, 8],
+    skus: [{ suffix: 'OLD', currentStock: 50, preOrderedStock: 10, isActive: true, isCurrent: false }],
+    expected: [9, 1, 8],
+  },
+  {
+    code: 'REPORT-NO-SKU',
+    name: '无规格旧数据商品',
+    mainStock: [6, 2, 4],
+    skus: [],
+    expected: [6, 2, 4],
+  },
+]
+
+const reportTitleMap: Record<ReportType, string> = {
+  inventory: '库存一览表',
+  'tag-sales': '标签销售汇总表',
+  kingdee: '金蝶汇总表',
+  walkin: '散客汇总表',
+  'outbound-flow': '出库单流水表',
+}
+
+function cleanupSqliteFile() {
+  for (const suffix of ['', '-shm', '-wal']) {
+    const target = `${sqlitePath}${suffix}`
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { force: true })
+    }
+  }
+}
+
+function stockFromRow(row: Record<string, unknown>): StockTriple {
+  return [Number(row.currentStock), Number(row.preOrderedStock), Number(row.availableStock)]
+}
+
+function collectStockMismatches(
+  source: string,
+  rows: Array<Record<string, unknown>>,
+  mismatches: string[],
+) {
+  const rowMap = new Map(rows.map((row) => [String(row.productCode), row]))
+  for (const fixture of fixtures) {
+    const row = rowMap.get(fixture.code)
+    if (!row) {
+      mismatches.push(`${source} 缺少 ${fixture.code}`)
+      continue
+    }
+    const actual = stockFromRow(row)
+    if (actual.some((value, index) => value !== fixture.expected[index])) {
+      mismatches.push(`${source} ${fixture.code} 期望 ${fixture.expected.join('/')}，实际 ${actual.join('/')}`)
+    }
+  }
+}
+
+async function exportReportBuffer(
+  reportService: typeof import('../src/services/report.service.js').reportService,
+  type: ReportType,
+  input: ReportQueryInput,
+): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  const output = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      callback()
+    },
+  })
+  await reportService.exportExcel(type, input, output, undefined, `report-${type}-${verifySeed}`)
+  return Buffer.concat(chunks)
+}
+
+async function parseReportExcel(buffer: Buffer, type: ReportType) {
+  const workbook = new ExcelJS.Workbook()
+  await workbook.xlsx.load(buffer)
+  const worksheet = workbook.getWorksheet(reportTitleMap[type])
+  assert.ok(worksheet, `流式导出必须生成${reportTitleMap[type]}工作表`)
+  assert.equal(worksheet.views[0]?.state, 'frozen', `${reportTitleMap[type]}必须冻结表头`)
+  assert.equal(worksheet.views[0]?.ySplit, 5, `${reportTitleMap[type]}必须冻结前五行`)
+  const headers = (worksheet.getRow(5).values as unknown[]).slice(1).map((value) => String(value ?? ''))
+  const rows: unknown[][] = []
+  for (let rowNumber = 6; rowNumber <= worksheet.rowCount; rowNumber += 1) {
+    const values = (worksheet.getRow(rowNumber).values as unknown[]).slice(1)
+    if (!values.every((value) => value === null || value === undefined || value === '')) {
+      rows.push(values)
+    }
+  }
+  return { headers, rows }
+}
+
+async function parseInventoryExcel(buffer: Buffer): Promise<Array<Record<string, unknown>>> {
+  const { headers, rows: worksheetRows } = await parseReportExcel(buffer, 'inventory')
+  assert.deepEqual(headers, ['商品编码', '当前库存', '预订库存', '可用库存'])
+  return worksheetRows.map((values) => ({
+      productCode: values[0],
+      currentStock: values[1],
+      preOrderedStock: values[2],
+      availableStock: values[3],
+  }))
+}
+
+async function main() {
+  fs.mkdirSync(sqliteRoot, { recursive: true })
+  const { AppDataSource } = await import('../src/config/data-source.js')
+  const { initializeDatabaseSchemaIfNeeded, prepareDatabaseRuntime } = await import('../src/config/database-bootstrap.js')
+  const { BaseProduct } = await import('../src/entities/base-product.entity.js')
+  const { BaseProductSku } = await import('../src/entities/base-product-sku.entity.js')
+  const { BaseTag } = await import('../src/entities/base-tag.entity.js')
+  const { RelProductTag } = await import('../src/entities/rel-product-tag.entity.js')
+  const { InventoryLog } = await import('../src/entities/inventory-log.entity.js')
+  const { ClientUser } = await import('../src/entities/client-user.entity.js')
+  const { SysUser } = await import('../src/entities/sys-user.entity.js')
+  const { inboundService } = await import('../src/services/inbound.service.js')
+  const { o2oPreorderService } = await import('../src/services/o2o-preorder.service.js')
+  const { orderService } = await import('../src/services/order.service.js')
+  const { productService } = await import('../src/services/product.service.js')
+  const { reportService } = await import('../src/services/report.service.js')
+  const { systemConfigService } = await import('../src/services/system-config.service.js')
+  const { summarizeProductInventory } = await import('../src/utils/product-inventory-summary.js')
+
+  assert.deepEqual(
+    summarizeProductInventory(
+      { currentStock: '99', preOrderedStock: '88' },
+      [{ currentStock: '-3', preOrderedStock: '2', isActive: 'true', isCurrent: 'true' }],
+    ),
+    { currentStock: 0, preOrderedStock: 2, availableStock: 0 },
+    'SKU 数字字符串应沿用 Math.max(0, Number(value))，flag 字符串 true 应保持启用',
+  )
+  assert.deepEqual(
+    summarizeProductInventory(
+      { currentStock: '-4', preOrderedStock: '-2' },
+      [{ currentStock: '30', preOrderedStock: '10', isActive: 'true', isCurrent: 'false' }],
+    ),
+    { currentStock: -4, preOrderedStock: -2, availableStock: 0 },
+    '无当前 SKU 时应原样保留主表 Number(...) 回退语义',
+  )
+  const nonFiniteSkuSummary = summarizeProductInventory(
+    { currentStock: '8', preOrderedStock: '2' },
+    [{ currentStock: 'not-a-number', preOrderedStock: '1', isActive: true, isCurrent: true }],
+  )
+  assert.equal(Number.isNaN(nonFiniteSkuSummary.currentStock), true, 'SKU 非数值应保持既有 NaN 语义，不得静默归零')
+  assert.deepEqual(
+    summarizeProductInventory(
+      { currentStock: '7', preOrderedStock: '1' },
+      [false, 0, '0', 'false'].map((isCurrent) => ({
+        currentStock: 99,
+        preOrderedStock: 88,
+        isActive: true,
+        isCurrent,
+      })),
+    ),
+    { currentStock: 7, preOrderedStock: 1, availableStock: 6 },
+    'false/0/字符串 0/字符串 false 都必须被识别为非当前 SKU',
+  )
+  assert.deepEqual(
+    summarizeProductInventory(
+      { currentStock: '7', preOrderedStock: '1' },
+      [false, 0, '0', 'false'].map((isActive) => ({
+        currentStock: 99,
+        preOrderedStock: 88,
+        isActive,
+        isCurrent: true,
+      })),
+    ),
+    { currentStock: 0, preOrderedStock: 0, availableStock: 0 },
+    '存在当前 SKU 但全部以兼容假值停用时库存必须为零，不能回退主表',
+  )
+
+  prepareDatabaseRuntime()
+  await AppDataSource.initialize()
+  try {
+    await initializeDatabaseSchemaIfNeeded(AppDataSource)
+    await systemConfigService.ensureDefaultConfigs()
+    const productRepo = AppDataSource.getRepository(BaseProduct)
+    const skuRepo = AppDataSource.getRepository(BaseProductSku)
+    const tagRepo = AppDataSource.getRepository(BaseTag)
+    const relationRepo = AppDataSource.getRepository(RelProductTag)
+    const inventoryLogRepo = AppDataSource.getRepository(InventoryLog)
+    const tag = await tagRepo.save(tagRepo.create({
+      tagName: `库存报表验证-${verifySeed}`,
+      tagCode: `REPORT-${verifySeed}`,
+    }))
+
+    for (const [fixtureIndex, fixture] of fixtures.entries()) {
+      const product = await productRepo.save(productRepo.create({
+        productCode: `${fixture.code}-${verifySeed}`,
+        productName: fixture.name,
+        pinyinAbbr: 'KCBG',
+        defaultPrice: '10.00',
+        discountRate: '10.0',
+        isActive: true,
+        o2oStatus: 'unlisted',
+        o2oRecommended: false,
+        thumbnail: null,
+        detailContent: null,
+        limitPerUser: 20,
+        currentStock: fixture.mainStock[0],
+        preOrderedStock: fixture.mainStock[1],
+      }))
+      await relationRepo.save(relationRepo.create({ productId: product.id, tagId: tag.id }))
+      if (fixture.skus.length > 0) {
+        await skuRepo.save(fixture.skus.map((sku, skuIndex) => skuRepo.create({
+          productId: product.id,
+          skuCode: `${fixture.code}-${sku.suffix}-${verifySeed}`,
+          specValuesJson: JSON.stringify({ 规格: sku.suffix }),
+          specText: sku.suffix,
+          defaultPrice: '10.00',
+          discountRate: '10.0',
+          currentStock: sku.currentStock,
+          preOrderedStock: sku.preOrderedStock,
+          isActive: sku.isActive,
+          isCurrent: sku.isCurrent,
+          o2oRecommended: false,
+          thumbnail: null,
+          sortOrder: fixtureIndex * 10 + skuIndex,
+        })))
+      }
+      fixture.code = String(product.productCode)
+    }
+
+    const beforeSnapshot = {
+      products: await productRepo.find({ order: { id: 'ASC' } }),
+      skus: await skuRepo.find({ order: { id: 'ASC' } }),
+      inventoryLogs: await inventoryLogRepo.find({ order: { id: 'ASC' } }),
+    }
+    const mismatches: string[] = []
+    const productViews = await productService.list({ tagId: String(tag.id) })
+    collectStockMismatches('商品服务', productViews as unknown as Array<Record<string, unknown>>, mismatches)
+
+    const reportInput = {
+      page: 1,
+      pageSize: 100,
+      tagIds: [String(tag.id)],
+      fields: ['productCode', 'currentStock', 'preOrderedStock', 'availableStock'],
+    }
+    const preview = await reportService.query('inventory', reportInput)
+    assert.equal(preview.total, fixtures.length)
+    collectStockMismatches('报表预览', preview.list, mismatches)
+
+    const excelRows = await parseInventoryExcel(await exportReportBuffer(reportService, 'inventory', reportInput))
+    assert.equal(excelRows.length, fixtures.length)
+    collectStockMismatches('Excel 导出', excelRows, mismatches)
+
+    const afterSnapshot = {
+      products: await productRepo.find({ order: { id: 'ASC' } }),
+      skus: await skuRepo.find({ order: { id: 'ASC' } }),
+      inventoryLogs: await inventoryLogRepo.find({ order: { id: 'ASC' } }),
+    }
+    assert.deepEqual(afterSnapshot, beforeSnapshot, '商品/报表/Excel 读取前后不得修改商品、SKU 或库存流水')
+    assert.deepEqual(mismatches, [], mismatches.join('\n'))
+
+    const pagedCodes: string[] = []
+    for (let page = 1; page <= 3; page += 1) {
+      const paged = await reportService.query('inventory', {
+        page,
+        pageSize: 2,
+        tagIds: [String(tag.id)],
+        fields: ['productCode', 'currentStock'],
+      })
+      assert.equal(paged.total, fixtures.length)
+      assert.deepEqual(paged.fields.map((field) => field.key), ['productCode', 'currentStock'])
+      pagedCodes.push(...paged.list.map((row) => String(row.productCode)))
+    }
+    assert.equal(new Set(pagedCodes).size, fixtures.length, '库存预览分页不得出现重复或漏行')
+    assert.deepEqual(new Set(pagedCodes), new Set(fixtures.map((fixture) => fixture.code)))
+
+    for (const type of ['tag-sales', 'kingdee', 'walkin', 'outbound-flow'] as const) {
+      const { headers, rows } = await parseReportExcel(await exportReportBuffer(reportService, type, {}), type)
+      assert.deepEqual(headers, reportService.getFieldDefinitions(type).map((field) => field.label))
+      assert.equal(rows.length, 0, `${reportTitleMap[type]}空结果导出不得生成伪数据行`)
+    }
+
+    const fillerProducts = Array.from({ length: 501 }, (_, index) => productRepo.create({
+      productCode: `REPORT-BATCH-${String(index + 1).padStart(3, '0')}-${verifySeed}`,
+      productName: `跨批次库存商品${String(index + 1).padStart(3, '0')}`,
+      pinyinAbbr: 'KPCB',
+      defaultPrice: '1.00',
+      discountRate: '10.0',
+      isActive: true,
+      o2oStatus: 'unlisted',
+      o2oRecommended: false,
+      thumbnail: null,
+      detailContent: null,
+      limitPerUser: 20,
+      currentStock: index % 9,
+      preOrderedStock: 0,
+    }))
+    await productRepo.save(fillerProducts, { chunk: 100 })
+    const beforeLargeExport = {
+      products: await productRepo.find({ order: { id: 'ASC' } }),
+      skus: await skuRepo.find({ order: { id: 'ASC' } }),
+      inventoryLogs: await inventoryLogRepo.find({ order: { id: 'ASC' } }),
+    }
+    const expectedCodes = beforeLargeExport.products.map((product) => product.productCode)
+    const largeExport = await parseReportExcel(
+      await exportReportBuffer(reportService, 'inventory', { fields: ['productCode'] }),
+      'inventory',
+    )
+    assert.deepEqual(largeExport.headers, ['商品编码'])
+    const exportedCodes = largeExport.rows.map((row) => String(row[0]))
+    assert.equal(exportedCodes.length, expectedCodes.length, '跨 500 行批次导出不得漏行')
+    assert.equal(new Set(exportedCodes).size, expectedCodes.length, '跨 500 行批次导出不得重复')
+    assert.deepEqual(new Set(exportedCodes), new Set(expectedCodes), '跨批次导出商品集合必须与数据库固定集合一致')
+    const afterLargeExport = {
+      products: await productRepo.find({ order: { id: 'ASC' } }),
+      skus: await skuRepo.find({ order: { id: 'ASC' } }),
+      inventoryLogs: await inventoryLogRepo.find({ order: { id: 'ASC' } }),
+    }
+    assert.deepEqual(afterLargeExport, beforeLargeExport, '跨批次导出前后不得修改商品、SKU 或库存流水')
+
+    const lifecycleTag = await tagRepo.save(tagRepo.create({
+      tagName: `库存生命周期-${verifySeed}`,
+      tagCode: `LIFECYCLE-${verifySeed}`,
+    }))
+    const lifecycleProduct = await productService.create({
+      productCode: `REPORT-LIFECYCLE-${verifySeed}`,
+      productName: `库存生命周期商品-${verifySeed}`,
+      pinyinAbbr: 'KCSMZQ',
+      defaultPrice: 10,
+      discountRate: 10,
+      isActive: true,
+      o2oStatus: 'listed',
+      currentStock: 10,
+      limitPerUser: 20,
+      tagIds: [String(lifecycleTag.id)],
+    })
+    const lifecycleSku = lifecycleProduct.skus[0]
+    assert.ok(lifecycleSku, '生命周期商品必须生成默认 SKU')
+
+    const readStoredLifecycleState = async () => {
+      const [product, skus, logs] = await Promise.all([
+        productRepo.findOneByOrFail({ id: lifecycleProduct.id }),
+        skuRepo.find({ where: { productId: lifecycleProduct.id }, order: { id: 'ASC' } }),
+        inventoryLogRepo.find({ where: { productId: lifecycleProduct.id }, order: { id: 'ASC' } }),
+      ])
+      return {
+        product: [Number(product.currentStock), Number(product.preOrderedStock)],
+        skus: skus.map((sku) => [
+          String(sku.id),
+          Number(sku.currentStock),
+          Number(sku.preOrderedStock),
+          sku.isActive,
+          sku.isCurrent,
+        ]),
+        logs: logs.map((log) => [
+          String(log.id),
+          log.changeType,
+          Number(log.changeQty),
+          Number(log.beforeCurrentStock),
+          Number(log.afterCurrentStock),
+          Number(log.beforePreorderedStock),
+          Number(log.afterPreorderedStock),
+        ]),
+      }
+    }
+
+    const assertLifecycleStock = async (expected: StockTriple, scene: string) => {
+      const storedBefore = await readStoredLifecycleState()
+      const detail = await productService.detail(lifecycleProduct.id)
+      assert.deepEqual(
+        [detail.currentStock, detail.preOrderedStock, detail.availableStock],
+        expected,
+        `${scene}：商品服务库存不符`,
+      )
+      const lifecycleInput: ReportQueryInput = {
+        tagIds: [String(lifecycleTag.id)],
+        fields: ['productCode', 'currentStock', 'preOrderedStock', 'availableStock'],
+      }
+      const lifecyclePreview = await reportService.query('inventory', lifecycleInput)
+      assert.equal(lifecyclePreview.total, 1, `${scene}：生命周期标签只能命中一个商品`)
+      assert.deepEqual(stockFromRow(lifecyclePreview.list[0] ?? {}), expected, `${scene}：报表预览库存不符`)
+      const lifecycleExcelRows = await parseInventoryExcel(
+        await exportReportBuffer(reportService, 'inventory', lifecycleInput),
+      )
+      assert.equal(lifecycleExcelRows.length, 1, `${scene}：Excel 只能包含一个生命周期商品`)
+      assert.deepEqual(stockFromRow(lifecycleExcelRows[0] ?? {}), expected, `${scene}：Excel 库存不符`)
+      assert.deepEqual(await readStoredLifecycleState(), storedBefore, `${scene}：三个读取出口不得修改库存或流水`)
+    }
+
+    await assertLifecycleStock([10, 0, 10], '初始库存')
+
+    const supplierRepo = AppDataSource.getRepository(SysUser)
+    const supplier = await supplierRepo.save(supplierRepo.create({
+      username: `report-supplier-${verifySeed}`,
+      passwordHash: 'verify-only',
+      displayName: '库存报表验证供货方',
+      email: null,
+      role: 'supplier',
+      status: 'enabled',
+      lastLoginAt: null,
+    }))
+    const supplierActor: AuthUserContext = {
+      userId: String(supplier.id),
+      username: supplier.username,
+      displayName: supplier.displayName,
+      role: 'supplier',
+      permissions: [],
+      status: 'enabled',
+      sessionToken: 'report-inventory-supplier',
+      authSource: 'bearer',
+    }
+    const adminActor: AuthUserContext = {
+      ...supplierActor,
+      userId: 'report-inventory-admin',
+      username: 'report-inventory-admin',
+      displayName: '库存报表验证管理员',
+      role: 'admin',
+      sessionToken: 'report-inventory-admin-session',
+    }
+    const inbound = await inboundService.submitSupplierDelivery(supplierActor, {
+      remark: '库存报表真实入库验证',
+      items: [{ productId: lifecycleProduct.id, skuId: lifecycleSku.id, qty: 5 }],
+    })
+    await inboundService.verifyInbound(inbound.order.verifyCode, adminActor)
+    await assertLifecycleStock([15, 0, 15], '入库后')
+
+    const clientRepo = AppDataSource.getRepository(ClientUser)
+    const client = await clientRepo.save(clientRepo.create({
+      mobile: `1${Date.now().toString().slice(-10)}`,
+      email: null,
+      mobileVerifiedAt: new Date(),
+      emailVerifiedAt: null,
+      passwordHash: 'verify-only',
+      realName: '库存报表验证客户',
+      departmentName: '',
+      accountType: 'personal',
+      staffNo: null,
+      staffVerified: false,
+      status: 'enabled',
+      lastLoginAt: null,
+    }))
+    const clientAuth: ClientAuthContext = {
+      userId: String(client.id),
+      account: client.mobile,
+      mobile: client.mobile,
+      email: '',
+      realName: client.realName,
+      accountType: 'personal',
+      staffNo: null,
+      sessionToken: 'report-inventory-client-session',
+    }
+
+    const cancelledPreorder = await o2oPreorderService.submit(clientAuth, {
+      clientRequestId: `report-inventory-cancel-${verifySeed}`,
+      items: [{ productId: lifecycleProduct.id, skuId: lifecycleSku.id, qty: 2 }],
+      pickupContact: '库存报表验证客户',
+      isSystemApplied: false,
+    })
+    await assertLifecycleStock([15, 2, 13], '预占后')
+    await o2oPreorderService.cancelMyOrder(clientAuth, cancelledPreorder.order.id)
+    await assertLifecycleStock([15, 0, 15], '取消后')
+
+    const verifiedPreorder = await o2oPreorderService.submit(clientAuth, {
+      clientRequestId: `report-inventory-verify-${verifySeed}`,
+      items: [{ productId: lifecycleProduct.id, skuId: lifecycleSku.id, qty: 3 }],
+      pickupContact: '库存报表验证客户',
+      isSystemApplied: false,
+    })
+    await assertLifecycleStock([15, 3, 12], '核销前预占后')
+    await o2oPreorderService.verifyByCode(verifiedPreorder.order.verifyCode, adminActor)
+    await assertLifecycleStock([12, 0, 12], '核销后')
+
+    const returnRequest = await o2oPreorderService.createReturnRequest(clientAuth, verifiedPreorder.order.id, {
+      reason: '库存报表真实退货验证',
+      items: [{ productId: lifecycleProduct.id, skuId: lifecycleSku.id, qty: 1 }],
+    })
+    await o2oPreorderService.verifyByCode(returnRequest.verifyCode, adminActor)
+    await assertLifecycleStock([13, 0, 13], '退货后')
+
+    const beforeOrdinaryOrder = await readStoredLifecycleState()
+    await orderService.submit({
+      idempotencyKey: `report-inventory-ordinary-${verifySeed}`,
+      orderType: 'walkin',
+      customerName: '库存报表普通出库验证',
+      items: [{ productId: lifecycleProduct.id, qty: 2, unitPrice: 10 }],
+    }, adminActor)
+    assert.deepEqual(await readStoredLifecycleState(), beforeOrdinaryOrder, '普通出库保存单据与价格时不得改变商品/SKU库存或库存流水')
+    await assertLifecycleStock([13, 0, 13], '普通出库后')
+
+    console.log('库存报表专项验证通过：固定口径、分页、跨批次、真实 Excel 与库存生命周期均一致')
+  } finally {
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy()
+    }
+    cleanupSqliteFile()
+  }
+}
+
+main().catch((error) => {
+  console.error(`[report-inventory-verify] 验证失败：${error instanceof Error ? error.stack ?? error.message : String(error)}`)
+  cleanupSqliteFile()
+  process.exitCode = 1
+})

--- a/backend/src/services/product.service.ts
+++ b/backend/src/services/product.service.ts
@@ -21,6 +21,7 @@ import type { PaginationResult } from '../types/api.js'
 import { isRetryableSqliteLockError, isUniqueConstraintError } from '../utils/database-errors.js'
 import { BizError } from '../utils/errors.js'
 import { generateProductCode } from '../utils/id-generator.js'
+import { isDatabaseFlagEnabled, summarizeProductInventory } from '../utils/product-inventory-summary.js'
 import { normalizeLegacyUploadUrl } from '../utils/upload-storage.js'
 import { assertDiscountRateInRange, calculateDiscountedPrice, normalizeDiscountRate } from '../utils/discount-price.js'
 import { invalidateMallCatalogReadCache } from './mall-catalog-revision.service.js'
@@ -238,10 +239,6 @@ const buildSpecValuesKey = (specValues: Record<string, string>): string => {
 
 const buildSkuEntitySpecValuesKey = (sku: Pick<BaseProductSku, 'specValuesJson'>): string => {
   return buildSpecValuesKey(parseSpecValuesJson(sku.specValuesJson))
-}
-
-const isDatabaseFlagEnabled = (value: unknown): boolean => {
-  return value !== false && value !== 0 && value !== '0' && value !== 'false'
 }
 
 const PRODUCT_CODE_CONSTRAINT_MATCHER = {
@@ -852,12 +849,9 @@ export class ProductService {
     return products.map((product) => {
       const productId = normalizeEntityId(product.id)
       const tags = productTagMap.get(productId) ?? []
-      const productSkus = (productSkuMap.get(productId) ?? []).filter((sku) => isDatabaseFlagEnabled(sku.isCurrent))
-      const activeCurrentSkus = productSkus.filter((sku) => isDatabaseFlagEnabled(sku.isActive))
-      const skuCurrentStock = activeCurrentSkus.reduce((sum, sku) => sum + sku.currentStock, 0)
-      const skuPreOrderedStock = activeCurrentSkus.reduce((sum, sku) => sum + sku.preOrderedStock, 0)
-      const currentStock = productSkus.length ? skuCurrentStock : Number(product.currentStock ?? 0)
-      const preOrderedStock = productSkus.length ? skuPreOrderedStock : Number(product.preOrderedStock ?? 0)
+      const allProductSkus = productSkuMap.get(productId) ?? []
+      const productSkus = allProductSkus.filter((sku) => isDatabaseFlagEnabled(sku.isCurrent))
+      const inventory = summarizeProductInventory(product, allProductSkus)
 
       return {
         id: productId,
@@ -873,9 +867,7 @@ export class ProductService {
         thumbnail: normalizeProductThumbnailUrl(product.thumbnail) ?? null,
         detailContent: product.detailContent ?? null,
         limitPerUser: Number(product.limitPerUser ?? 5),
-        currentStock,
-        preOrderedStock,
-        availableStock: Math.max(0, currentStock - preOrderedStock),
+        ...inventory,
         tagIds: tags.map((tag) => tag.id),
         tags,
         specGroups: this.buildSpecGroupsFromSkus(productSkus),

--- a/backend/src/services/report.service.ts
+++ b/backend/src/services/report.service.ts
@@ -15,11 +15,13 @@ import type { Writable } from 'node:stream'
 import { In } from 'typeorm'
 import { AppDataSource } from '../config/data-source.js'
 import { BaseProduct } from '../entities/base-product.entity.js'
+import { BaseProductSku } from '../entities/base-product-sku.entity.js'
 import { BizOutboundOrder } from '../entities/biz-outbound-order.entity.js'
 import { BizOutboundOrderItem } from '../entities/biz-outbound-order-item.entity.js'
 import { RelProductTag } from '../entities/rel-product-tag.entity.js'
 import type { PaginationResult } from '../types/api.js'
 import { BizError } from '../utils/errors.js'
+import { summarizeProductInventory } from '../utils/product-inventory-summary.js'
 
 export const REPORT_TYPES = ['inventory', 'tag-sales', 'kingdee', 'walkin', 'outbound-flow'] as const
 export type ReportType = (typeof REPORT_TYPES)[number]
@@ -333,7 +335,9 @@ export class ReportService {
     })
     workbook.creator = 'Y-Link'
     workbook.created = new Date()
-    const worksheet = workbook.addWorksheet(REPORT_TITLE_MAP[type])
+    const worksheet = workbook.addWorksheet(REPORT_TITLE_MAP[type], {
+      views: [{ state: 'frozen', ySplit: 5 }],
+    })
     this.initializeWorksheet(worksheet, REPORT_TITLE_MAP[type], query.fields, input)
 
     let exportedRows = 0
@@ -439,26 +443,43 @@ export class ReportService {
       qb.skip((query.page - 1) * query.pageSize)
     }
     const products = await qb.getMany()
-    const relations = products.length > 0
-      ? await relationRepo.find({
-          where: { productId: In(products.map((product) => String(product.id))) },
+    const productIds = products.map((product) => String(product.id))
+    const [relations, skus] = products.length > 0
+      ? await Promise.all([
+        relationRepo.find({
+          where: { productId: In(productIds) },
           relations: { tag: true },
           order: { id: 'ASC' },
-        })
-      : []
+        }),
+        AppDataSource.getRepository(BaseProductSku).find({
+          select: {
+            productId: true,
+            currentStock: true,
+            preOrderedStock: true,
+            isActive: true,
+            isCurrent: true,
+          },
+          where: { productId: In(productIds) },
+        }),
+      ])
+      : [[], []]
     const tagMap = this.buildProductTagMap(relations)
+    const skuMap = new Map<string, BaseProductSku[]>()
+    skus.forEach((sku) => {
+      const productId = String(sku.productId)
+      const productSkus = skuMap.get(productId) ?? []
+      productSkus.push(sku)
+      skuMap.set(productId, productSkus)
+    })
     const rows = products.map((product) => {
       const tags = tagMap.get(String(product.id)) ?? []
-      const currentStock = Number(product.currentStock ?? 0)
-      const preOrderedStock = Number(product.preOrderedStock ?? 0)
+      const inventory = summarizeProductInventory(product, skuMap.get(String(product.id)) ?? [])
       return {
         category: tags.length > 0 ? tags.join('、') : '未分类',
         productCode: product.productCode,
         productName: product.productName,
         defaultPrice: normalizeAmount(product.defaultPrice),
-        currentStock,
-        preOrderedStock,
-        availableStock: Math.max(0, currentStock - preOrderedStock),
+        ...inventory,
         status: product.isActive ? '启用' : '停用',
       }
     })
@@ -728,7 +749,6 @@ export class ReportService {
       }
     })
 
-    worksheet.views = [{ state: 'frozen', ySplit: 5 }]
     worksheet.getRow(1).commit()
     worksheet.getRow(2).commit()
     worksheet.getRow(3).commit()

--- a/backend/src/utils/product-inventory-summary.ts
+++ b/backend/src/utils/product-inventory-summary.ts
@@ -1,0 +1,48 @@
+/**
+ * 商品库存读取口径：只聚合仍属于当前规格矩阵且启用的 SKU；若不存在当前 SKU，回退商品主表。
+ * 该函数无状态且不访问数据库，供商品视图与库存报表共享，避免两个出口再次出现数值分叉。
+ */
+
+export interface ProductInventoryValueSource {
+  currentStock?: unknown
+  preOrderedStock?: unknown
+}
+
+export interface ProductInventorySkuSource extends ProductInventoryValueSource {
+  isActive?: unknown
+  isCurrent?: unknown
+}
+
+export interface ProductInventorySummary {
+  currentStock: number
+  preOrderedStock: number
+  availableStock: number
+}
+
+export const isDatabaseFlagEnabled = (value: unknown): boolean => {
+  return value !== false && value !== 0 && value !== '0' && value !== 'false'
+}
+
+export const normalizeSkuInventoryQuantity = (value: unknown): number => {
+  return Math.max(0, Number(value ?? 0))
+}
+
+export const summarizeProductInventory = (
+  product: ProductInventoryValueSource,
+  skus: ProductInventorySkuSource[],
+): ProductInventorySummary => {
+  const currentSkus = skus.filter((sku) => isDatabaseFlagEnabled(sku.isCurrent))
+  const activeCurrentSkus = currentSkus.filter((sku) => isDatabaseFlagEnabled(sku.isActive))
+  const currentStock = currentSkus.length > 0
+    ? activeCurrentSkus.reduce((sum, sku) => sum + normalizeSkuInventoryQuantity(sku.currentStock), 0)
+    : Number(product.currentStock ?? 0)
+  const preOrderedStock = currentSkus.length > 0
+    ? activeCurrentSkus.reduce((sum, sku) => sum + normalizeSkuInventoryQuantity(sku.preOrderedStock), 0)
+    : Number(product.preOrderedStock ?? 0)
+
+  return {
+    currentStock,
+    preOrderedStock,
+    availableStock: Math.max(0, currentStock - preOrderedStock),
+  }
+}

--- a/docs/project-context/21-工作台、报表与出库链路.md
+++ b/docs/project-context/21-工作台、报表与出库链路.md
@@ -56,6 +56,7 @@
   - 库存、标签销售、金蝶、散客、出库流水等报表类型
   - 字段定义、分页查询、导出 Excel
   - 部门单与散客单字段差异兜底
+  - 库存预览与 Excel 导出按当前且启用的 SKU 汇总 `currentStock`、`preOrderedStock`；仅当商品没有当前 SKU 时回退商品主表
 
 ## 关键状态/字段/快照
 
@@ -100,3 +101,4 @@
 - 工作台回归：四宫格、区间筛选（按日/按月、跨月跨年）、饼图、趋势、商品榜合并/细分、Top N 切换、钻取、近期动态文案。
 - 工作台自动化回归命令：`npm --prefix backend run dashboard:analytics:verify`。
 - 报表回归：报表类型切换、字段列头、分页、导出文件名。
+- 库存口径专项：`npm --prefix backend run reports:inventory:verify`。该脚本使用唯一临时 SQLite，核对商品服务、预览和实际 Excel，并覆盖标签、自定义字段、500 行跨批次及真实库存生命周期。

--- a/docs/project-context/22-产品、SKU、标签与 O2O 商品管理.md
+++ b/docs/project-context/22-产品、SKU、标签与 O2O 商品管理.md
@@ -43,7 +43,8 @@
 
 ## 关键状态/字段/快照
 
-- 产品主记录会聚合 SKU 库存：`currentStock`、`preOrderedStock`。
+- 商品视图的 `currentStock`、`preOrderedStock` 只汇总当前规格矩阵中启用的 SKU；存在当前 SKU 但全部停用时汇总为 0，仅无当前 SKU（包括只剩历史 SKU）时回退商品主表字段。
+- `availableStock` 统一按 `max(0, currentStock - preOrderedStock)` 计算；商品服务与库存报表复用同一纯汇总函数，报表查询不回写商品、SKU 或 `InventoryLog`。
 - SKU 关键字段：`skuCode`、`specText`、`specValuesJson`、`defaultPrice`、`discountRate`、`thumbnail`、`o2oRecommended`、`sortOrder`。
 - 若只有一个默认 SKU，产品与 SKU 会做双向同步，避免主记录和默认 SKU 口径分裂。
 - 标签关系通过中间关联表维护，不是产品表内简单字符串。
@@ -67,3 +68,4 @@
 - 产品修改后至少回归：产品列表、详情、SKU 展示、标签展示、库存总量、O2O 商品页。
 - 涉及折扣价格时同时回归：管理端商品视图、客户端商城、购物车、订单详情。
 - 批量更新或导入后回归：SKU 去重、默认规格、缩略图、排序和总库存聚合。
+- 库存展示或汇总口径改动后运行：`npm --prefix backend run reports:inventory:verify`、`npm --prefix backend run product:sku-current:verify`、`npm --prefix backend run inventory:invariants:verify`。

--- a/docs/project-context/52-验证脚本与高风险操作.md
+++ b/docs/project-context/52-验证脚本与高风险操作.md
@@ -52,6 +52,7 @@
   - `npm --prefix backend run task2:route-contract:verify`
   - `npm --prefix backend run security:hardening:verify`
 - O2O、订单、入库、通知等已有专项验证脚本时，应优先使用对应脚本而不是只跑构建。
+- 商品库存展示、库存报表或 Excel 库存列变更后，应运行 `npm --prefix backend run reports:inventory:verify`；它使用唯一临时 SQLite，真实解析流式 Excel，并验证 SKU 汇总、标签分页、500 行批次、库存生命周期和只读边界。
 - 依赖文件变化时，应在本地执行 `npm audit --omit=dev` 与 `npm --prefix backend audit --omit=dev`；审计依赖外部 registry，不作为每个 PR 的稳定必过门禁。
 
 ## Web 安全与救援验证

--- a/src/views/reports/ReportCenterView.vue
+++ b/src/views/reports/ReportCenterView.vue
@@ -8,7 +8,7 @@
  * - 字段勾选只负责用户偏好，最终字段白名单仍由后端报表服务二次校验。
  * 维护说明：
  * - 新增报表类型时需要同步补齐本页字段定义、报表说明和后端 ReportType；
- * - 库存表第一版采用当前库存快照，不在页面层伪造月度库存回算。
+ * - 库存表展示当前且启用 SKU 的实时合计；无当前 SKU 的旧数据才回退商品主表，不在页面层重算。
  */
 
 import dayjs from 'dayjs'
@@ -37,7 +37,11 @@ interface ReportTypeOption {
 }
 
 const reportTypeOptions: ReportTypeOption[] = [
-  { label: '库存一览表', value: 'inventory', description: '按当前商品库存快照查看品类、售价、库存与状态。' },
+  {
+    label: '库存一览表',
+    value: 'inventory',
+    description: '当前库存按当前且启用的 SKU 合计；预订库存表示已占用数量；可用库存为当前库存减预订占用，最低显示为 0。',
+  },
   { label: '标签销售汇总表', value: 'tag-sales', description: '按时间段和标签查看商品销售明细，适用于品宣、联名、海右等分类查账。' },
   { label: '金蝶汇总表', value: 'kingdee', description: '仅统计部门单，包含部门、领取人、出库单与系统申请状态。' },
   { label: '散客汇总表', value: 'walkin', description: '仅统计个人购买，保留商品、数量、金额、领取人和操作人员。' },


### PR DESCRIPTION
报表库存预览和 Excel 原先直接读取商品主表，而产品基础资料按当前启用的 SKU 汇总；主表与规格记录存在差额时，两处显示不同。本 PR 让商品服务、库存预览和导出复用同一库存计算，并保留既有库存写入规则。

Closes #61

## 主要变更
- 统一当前库存、预订占用和可用库存：存在当前 SKU 时仅汇总启用项，全部停用时为零；没有当前 SKU 时沿用商品主表回退及原数值转换规则。
- 库存报表按预览页或 500 行导出批次批量读取必要 SKU 字段，避免逐商品查询和无用字段、排序开销。
- 修复真实导出测试发现的 ExcelJS 流式工作表 views 只读属性异常，改在创建工作表时配置冻结表头。
- 补充库存说明和专项验证，覆盖真实服务、实际 Excel 解析及库存生命周期。

## 本地验证
以下命令均在最终代码快照上执行并通过（exit 0）：
- `npm --prefix backend run reports:inventory:verify`
- `npm --prefix backend run reports:contract:verify`
- `npm --prefix backend run product:sku-current:verify`
- `npm --prefix backend run inventory:invariants:verify`
- `npm --prefix backend run o2o:stock-consistency:verify`
- `npm --prefix backend run build`
- `npm run build`
- `npm run verify:text-encoding`
- `git diff --check`

专项先复现旧报表与实际 Excel 的库存差异，再验证修复。覆盖默认/多规格、零库存、占用、停用/退役及无当前 SKU 回退、标签与自定义字段、分页、507 行跨批次导出、五类报表实际 Excel、入库/预占/取消/核销/退货及普通出库。查询和导出前后商品、SKU、库存流水保持不变。

## 兼容性与边界
- 未新增依赖，未改变 API 路径、字段、权限、数据库结构或库存写入业务；普通出库开单仍沿用既有不扣库存行为。
- 本次统一读取口径，不自动纠正历史持久库存差额，也未读取或修改生产业务数据。
- 未执行 MySQL 实例、浏览器交互和线上原始数据验收；SQLite 验证不代表这些环境已通过。
- 前端构建通过，仍有分包体积提示。远端 CI 以 PR 检查结果为准。
- 无迁移或额外配置要求；如需回退，可 revert 本 PR 的代码提交。